### PR TITLE
feat(lite): finalize create UI parity and navbar auth behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- Lite mode local-only workflow for event setup and dispatch, including browser-local persistence without Firebase sync.
+- Lite dispatch navbar controls for Posting Schedule, Clear Event, and Export Summary actions.
+
+### Changed
+
+- Unified Lite and Cloud dispatch onto a shared dispatch UI flow to reduce duplication and keep feature parity.
+- Lite dispatch navbar behavior now mirrors main app navbar behavior (clock placement, auth controls, desktop/mobile parity).
+- Lite dispatch route now uses a lightweight wrapper that delegates to the shared dispatch page.
+
 ### Fixed
+
+- Resolved Next.js route export/type issues on dispatch pages that could fail production builds.
+- Cleared lint/type build blockers across dispatch, venue management, profile, and modal components.
+- Updated venue map icon rendering to satisfy Next.js image lint requirements.
 
 - Suppressed non-actionable React hydration mismatch warnings in development when browser extensions inject attributes on root HTML/body before client hydration.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -16,6 +16,14 @@ This document is a short, user-focused guide to the primary workflows in CrowdCA
 4. Create or join a Team/Unit assigned to the Event.
 5. Use the Dispatch interface to log calls, assign teams, and close incidents.
 
+## Lite mode (local-only)
+
+- Open `/lite` to use CrowdCAD Lite without cloud sync.
+- Lite mode stores data in your browser (IndexedDB/local storage) on the current device.
+- In Lite Event Setup, you can add/edit locations, equipment, and teams before starting dispatch.
+- Teams can be edited from the Teams panel using the pencil icon.
+- Use this mode for quick local workflows when internet or account access is unavailable.
+
 ## Basic concepts
 
 - Event: an organized occurrence (concert, festival, sports match) with its own roster, venues and logs.

--- a/src/app/(main)/events/[eventId]/create/page.tsx
+++ b/src/app/(main)/events/[eventId]/create/page.tsx
@@ -2,9 +2,9 @@
 
 import { useRouter, useParams } from 'next/navigation';
 import { db } from '@/app/firebase';
-import { doc, getDoc, updateDoc, deleteDoc, collection, addDoc } from 'firebase/firestore';
+import { doc, getDoc, updateDoc, collection, addDoc } from 'firebase/firestore';
 import React, { useEffect, useRef, useState } from 'react';
-import { Event, Venue, Staff, Supervisor, Post, Equipment, EventEquipment } from '@/app/types';
+import { Event, Venue, Staff, Supervisor, Post, EventEquipment } from '@/app/types';
 import { getAuth } from 'firebase/auth';
 import Image from 'next/image';
 import { Tabs, Tab, Input, DatePicker, Select, SelectItem, Checkbox, Button, Card, ScrollShadow, Chip, TimeInput } from '@heroui/react';
@@ -18,11 +18,6 @@ import LoadingScreen from '@/components/ui/loading-screen';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 const LICENSES = ['CPR', 'EMT-B', 'EMT-A', 'EMT-P', 'RN', 'MD/DO'];
-
-// Helper to check if Post is an object with name property
-const isPostObject = (post: Post): post is { name: string; x: number | null; y: number | null } => {
-  return typeof post === 'object' && post !== null && 'name' in post;
-};
 
 // Helper to get post name regardless of type
 const getPostName = (post: Post): string => {
@@ -56,8 +51,8 @@ export default function EventCreation() {
   
   const containerRef = useRef<HTMLDivElement>(null);
   const imgContainerRef = useRef<HTMLDivElement>(null);
-  const [containerSize, setContainerSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
-  const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
+  const [, setContainerSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
+  const [, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
   const imgRef = useRef<HTMLImageElement>(null);
   const submittedRef = useRef(false);
 
@@ -149,10 +144,8 @@ export default function EventCreation() {
       try {
         const docRef = doc(db, 'events', eventId);
         await updateDoc(docRef, stripUndefined({ postingTimes: times }));
-        // eslint-disable-next-line no-console
         console.log('Autosaved postingTimes to draft:', { eventId, postingTimes: times });
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.error('Failed to autosave postingTimes:', err);
       }
     }, 600);
@@ -402,7 +395,6 @@ export default function EventCreation() {
       };
 
       const computedTimes = computePostingTimes();
-      // eslint-disable-next-line no-console
       console.log('handleSubmit computed postingTimes:', computedTimes, 'eventData.postingTimes:', eventData.postingTimes);
 
       let eventDocId = eventId;
@@ -419,7 +411,6 @@ export default function EventCreation() {
               updatedAt: new Date().toISOString(),
               status: 'active',
             }));
-            // eslint-disable-next-line no-console
             console.log('Event updated:', { eventId: eventDocId, postingTimes: eventData.postingTimes || [] });
           } else {
             const newDocRef = await addDoc(collection(db, 'events'), stripUndefined({
@@ -431,7 +422,6 @@ export default function EventCreation() {
               status: 'active',
             }));
             eventDocId = newDocRef.id;
-            // eslint-disable-next-line no-console
             console.log('Event created (branch new):', { eventId: eventDocId, postingTimes: eventData.postingTimes || [] });
           }
         } catch (error) {
@@ -444,7 +434,6 @@ export default function EventCreation() {
             status: 'active',
           }));
           eventDocId = newDocRef.id;
-          // eslint-disable-next-line no-console
           console.log('Event created (catch):', { eventId: eventDocId, postingTimes: eventData.postingTimes || [] });
         }
       } else {
@@ -456,7 +445,6 @@ export default function EventCreation() {
           status: 'active',
         }));
         eventDocId = docRef.id;
-        // eslint-disable-next-line no-console
         console.log('Event created (no eventId):', { eventId: eventDocId, postingTimes: eventData.postingTimes || [] });
       }
       router.push(`/events/${eventDocId}/dispatch`);

--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -27,14 +27,12 @@ import ClinicTrackingCard from '@/components/dispatch/clinictrackingcard';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
 import DebugModal from '@/components/modals/debugmodal';
 import { ShieldAlert } from 'lucide-react';
-import { Select, SelectItem, Tabs, Tab, Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Tooltip, Chip } from "@heroui/react"
+import { Select, SelectItem, Tabs, Tab, Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Tooltip } from "@heroui/react"
 import EquipmentCard from '@/components/dispatch/equipmentcard';
 import LoadingScreen from '@/components/ui/loading-screen';
 
-interface DispatchPageProps {
+interface DispatchRoutePageProps {
   params: Promise<{ eventId: string }>;
-  liteEventId?: string;
-  forceLiteMode?: boolean;
 }
 
 const LITE_LOCAL_USER_ID = 'lite-local';
@@ -241,16 +239,15 @@ const TeamWidget = React.memo(function TeamWidget(props: TeamWidgetProps) {
 
 const AUTO_POST_SYNC = false;
 
-export default function DispatchPage({ params, liteEventId, forceLiteMode = false }: DispatchPageProps) {
+export default function DispatchPage({ params }: DispatchRoutePageProps) {
   const [event, setEvent] = useState<Event | undefined>(undefined);
   const [postAssignments, setPostAssignments] = useState<PostAssignment>({});
   // const handleBulkPostAssignment = (newAssignments: PostAssignment) => {
   //   setPostAssignments(newAssignments);
   // };
-  const { eventId: routeEventId } = use(params);
+  const { eventId } = use(params);
   const { isLiteMode: layoutLiteMode } = useLiteMode();
-  const isLiteMode = forceLiteMode || layoutLiteMode;
-  const eventId = liteEventId ?? routeEventId;
+  const isLiteMode = layoutLiteMode;
   const { user: authUser, ready: authReady } = useAuth();
   const user = isLiteMode ? null : authUser;
   const ready = isLiteMode ? true : authReady;
@@ -935,98 +932,6 @@ export default function DispatchPage({ params, liteEventId, forceLiteMode = fals
 
     return 'bg-surface-deep';
   };
-
-
-  const ACTIVE_CALL_SET = new Set(['Assigned','En Route','On Scene','Transporting','Pending']);
-
-  const commitEquipmentLocation = async (resourceName: string, newLocationRaw: string) => {
-    if (!event) return;
-    const newLocation = newLocationRaw; // allow empty
-
-    let touched = false;
-    const updatedEquipment = (event.eventEquipment || []).map(eq => {
-      if (eq.name === resourceName) {
-        touched = true;
-        const inUse = !!eq.assignedTeam;
-        return {
-          ...eq,
-          location: newLocation,
-          status: inUse ? eq.status : ('Available' as EquipmentStatus),
-        };
-      }
-      return eq;
-    });
-
-    if (!touched) {
-      updatedEquipment.push({
-        id: `eq_${Date.now()}_${Math.random().toString(36).slice(2,8)}`,
-        name: resourceName,
-        status: ('Available' as EquipmentStatus),
-        location: newLocation,
-        assignedTeam: null,
-      });
-    }
-
-    await updateEvent({ eventEquipment: updatedEquipment });
-  };
-
-
-
-  const [equipmentDraft, setEquipmentDraft] = useState<Record<string, string>>({});
-
-  type EquipRow = {
-    name: string;
-    inUse: boolean;
-    rightText: string;   // shown in the UI
-    location: string;    // raw location value (can be '')
-  };
-
-
-  function getEquipmentRows(): EquipRow[] {
-    const venueEquipment = (event?.venue as { equipment?: (string | { name: string })[] })?.equipment ?? [];
-    const tracked = event?.eventEquipment ?? [];
-
-    const byName: Record<string, { name: string; assignedTeam?: string | null; location?: string | null; }> = {};
-
-    for (const v of venueEquipment) {
-      const name = typeof v === 'string' ? v : v?.name;
-      if (name) byName[name] = { name, assignedTeam: null, location: null };
-    }
-    for (const t of tracked) {
-      byName[t.name] = { name: t.name, assignedTeam: t.assignedTeam ?? null, location: t.location ?? null };
-    }
-
-    const rows = Object.values(byName).map(r => {
-      const inUse = !!(r.assignedTeam && r.assignedTeam.trim());
-      const location = r.location ?? ''; // raw value for editing (may be empty)
-      let rightText: string;
-
-      if (inUse) {
-        // compute "CallNum - Team(s)" (leave as you already had)
-        const call = (event?.calls ?? []).find(c =>
-          c.assignedTeam?.includes(r.assignedTeam!) && ACTIVE_CALL_SET.has(c.status)
-        );
-        if (call) {
-          const callNo = callDisplayNumberMap.get(call.id);
-          const teams = (call.assignedTeam ?? []).join(', ');
-          rightText = `${callNo} - ${teams}`;
-        } else {
-          rightText = `— - ${r.assignedTeam ?? ''}`;
-        }
-      } else {
-        rightText = location || 'Clinic';
-      }
-
-      return { name: r.name, inUse, location, rightText };
-    });
-
-    rows.sort((a, b) => {
-      if (a.inUse !== b.inUse) return a.inUse ? 1 : -1;
-      return a.name.localeCompare(b.name, undefined, { numeric: true });
-    });
-
-    return rows;
-  }
 
 
   async function handleAgeSexBlur(callId: string) {
@@ -1746,7 +1651,6 @@ export default function DispatchPage({ params, liteEventId, forceLiteMode = fals
       if (doc.exists()) {
         const eventData = doc.data() as Event;
         // Debug: log event document contents to diagnose missing postingTimes
-        // eslint-disable-next-line no-console
         console.log('Firestore snapshot - eventData:', {
           id: doc.id,
           postingTimes: eventData.postingTimes,

--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -15,6 +15,8 @@ import { toast, Slide } from 'react-toastify';
 import { useRouter } from 'next/navigation';
 import isEqual from 'lodash.isequal';
 import { useAuth } from '@/hooks/useauth';
+import { useLiteMode } from '@/lib/LiteContext';
+import { deleteLiteEvent, getLiteEvent, saveLiteEvent, type LiteEventDraft } from '@/lib/liteEventStore';
 import { Plus, RotateCw, ArrowDownWideNarrow, Rows2, Rows4} from "lucide-react";
 import TeamCard from '@/components/dispatch/teamcard';
 import TeamCardCondensed from '@/components/dispatch/teamcard-condensed';
@@ -25,12 +27,93 @@ import ClinicTrackingCard from '@/components/dispatch/clinictrackingcard';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable"
 import DebugModal from '@/components/modals/debugmodal';
 import { ShieldAlert } from 'lucide-react';
-import { Select, SelectItem, Tabs, Tab, Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Tooltip } from "@heroui/react"
+import { Select, SelectItem, Tabs, Tab, Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Tooltip, Chip } from "@heroui/react"
 import EquipmentCard from '@/components/dispatch/equipmentcard';
 import LoadingScreen from '@/components/ui/loading-screen';
 
 interface DispatchPageProps {
-  params: Promise<{ eventId: string }>
+  params: Promise<{ eventId: string }>;
+  liteEventId?: string;
+  forceLiteMode?: boolean;
+}
+
+const LITE_LOCAL_USER_ID = 'lite-local';
+
+function removeUndefinedDeep<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') return obj;
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => removeUndefinedDeep(item)) as unknown as T;
+  }
+
+  const cleaned = {} as Record<string, unknown>;
+  const record = obj as Record<string, unknown>;
+
+  Object.keys(record).forEach((key) => {
+    const val = removeUndefinedDeep(record[key]);
+    if (val !== undefined) cleaned[key] = val;
+  });
+
+  return cleaned as unknown as T;
+}
+
+function normalizeLiteDraftToEvent(draft: LiteEventDraft): Event {
+  const eventPosts = draft.eventPosts?.length ? draft.eventPosts : draft.venue.posts;
+
+  return {
+    id: draft.id,
+    name: draft.name,
+    date: draft.date,
+    venue: {
+      id: `lite-venue-${draft.id}`,
+      name: draft.venue.name || 'Lite Venue',
+      equipment: draft.venue.equipment || [],
+      posts: draft.venue.posts || [],
+      layers: [],
+      userId: LITE_LOCAL_USER_ID,
+      mapUrl: undefined,
+    },
+    userId: LITE_LOCAL_USER_ID,
+    postingTimes: draft.postingTimes || [],
+    staff: draft.staff || [],
+    supervisor: draft.supervisor || [],
+    calls: draft.calls || [],
+    status: draft.status,
+    createdAt: draft.createdAt,
+    eventPosts: eventPosts || [],
+    eventEquipment: draft.eventEquipment || [],
+    postAssignments: draft.postAssignments || {},
+    pendingAssignments: draft.pendingAssignments || {},
+  };
+}
+
+function toLiteDraftFromEvent(nextEvent: Event, previousDraft: LiteEventDraft): LiteEventDraft {
+  return {
+    ...previousDraft,
+    id: nextEvent.id || previousDraft.id,
+    mode: 'lite',
+    name: nextEvent.name ?? previousDraft.name,
+    date: nextEvent.date ?? previousDraft.date,
+    venue: {
+      name: nextEvent.venue?.name ?? previousDraft.venue.name,
+      posts: nextEvent.eventPosts ?? nextEvent.venue?.posts ?? previousDraft.venue.posts,
+      equipment: nextEvent.venue?.equipment ?? previousDraft.venue.equipment,
+    },
+    postingTimes: nextEvent.postingTimes || [],
+    staff: nextEvent.staff || [],
+    supervisor: nextEvent.supervisor || [],
+    eventPosts: nextEvent.eventPosts || [],
+    eventEquipment: nextEvent.eventEquipment || [],
+    calls: nextEvent.calls || [],
+    status: nextEvent.status ?? previousDraft.status ?? 'active',
+    postAssignments: nextEvent.postAssignments || {},
+    pendingAssignments: nextEvent.pendingAssignments || {},
+    createdAt:
+      typeof nextEvent.createdAt === 'string'
+        ? nextEvent.createdAt
+        : previousDraft.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 import ReactDOM from 'react-dom';
@@ -158,14 +241,19 @@ const TeamWidget = React.memo(function TeamWidget(props: TeamWidgetProps) {
 
 const AUTO_POST_SYNC = false;
 
-export default function DispatchPage({ params }: DispatchPageProps) {
+export default function DispatchPage({ params, liteEventId, forceLiteMode = false }: DispatchPageProps) {
   const [event, setEvent] = useState<Event | undefined>(undefined);
   const [postAssignments, setPostAssignments] = useState<PostAssignment>({});
   // const handleBulkPostAssignment = (newAssignments: PostAssignment) => {
   //   setPostAssignments(newAssignments);
   // };
-  const { eventId } = use(params);
-  const { user, ready } = useAuth();
+  const { eventId: routeEventId } = use(params);
+  const { isLiteMode: layoutLiteMode } = useLiteMode();
+  const isLiteMode = forceLiteMode || layoutLiteMode;
+  const eventId = liteEventId ?? routeEventId;
+  const { user: authUser, ready: authReady } = useAuth();
+  const user = isLiteMode ? null : authUser;
+  const ready = isLiteMode ? true : authReady;
   const router = useRouter();
   const [openCallId, setOpenCallId] = useState<string | null>(null);
   const [openClinicCallId, setOpenClinicCallId] = useState<string | null>(null);
@@ -234,6 +322,35 @@ export default function DispatchPage({ params }: DispatchPageProps) {
     updateInput: Partial<Event> | ((current: Event) => Partial<Event>)
   ) => {
     if (!eventId) return;
+
+    if (isLiteMode) {
+      try {
+        const currentDraft = await getLiteEvent(eventId);
+        if (!currentDraft) {
+          throw new Error('Lite event not found');
+        }
+
+        const currentEvent = normalizeLiteDraftToEvent(currentDraft);
+        const updates =
+          typeof updateInput === 'function' ? updateInput(currentEvent) : updateInput;
+
+        const nextEvent = {
+          ...currentEvent,
+          ...removeUndefinedDeep(updates),
+        } as Event;
+
+        const nextDraft = toLiteDraftFromEvent(nextEvent, currentDraft);
+        await saveLiteEvent(nextDraft);
+
+        setEvent(nextEvent);
+        setPostAssignments(nextEvent.postAssignments || {});
+      } catch (error) {
+        console.error('Local update failed:', error);
+        toast.error('Failed to save local changes. Please try again.');
+      }
+      return;
+    }
+
     try {
       await runTransaction(db, async (transaction) => {
         const eventRef = doc(db, "events", eventId);
@@ -249,31 +366,13 @@ export default function DispatchPage({ params }: DispatchPageProps) {
           updates = updateInput;
         }
 
-        const removeUndefined = <T,>(obj: T): T => {
-          if (obj === null || typeof obj !== 'object') return obj;
-
-          if (Array.isArray(obj)) {
-            return obj.map((item) => removeUndefined(item)) as unknown as T;
-          }
-
-          const cleaned = {} as Record<string, unknown>;
-          const record = obj as Record<string, unknown>;
-
-          Object.keys(record).forEach((key) => {
-            const val = removeUndefined(record[key]);
-            if (val !== undefined) cleaned[key] = val;
-          });
-
-          return cleaned as unknown as T;
-        };
-
-        transaction.update(eventRef, removeUndefined(updates));
+        transaction.update(eventRef, removeUndefinedDeep(updates));
       });
     } catch (error) {
       console.error("Update failed:", error);
       toast.error("Failed to save changes. Please try again.");
     }
-  }, [eventId]);
+  }, [eventId, isLiteMode]);
 
   const handlePostAssignment = useCallback(async (time: string, post: string, team: string) => {
     await updateEvent((currentEvent) => {
@@ -1593,14 +1692,56 @@ export default function DispatchPage({ params }: DispatchPageProps) {
 
    useEffect(() => {
     if (!eventId) {
-      console.error('eventId is undefined or null, skipping Firestore subscription');
+      console.error('eventId is undefined or null, skipping event subscription');
       return;
     }
-    
+
+    if (isLiteMode) {
+      let cancelled = false;
+
+      const loadLiteEvent = async () => {
+        try {
+          const draft = await getLiteEvent(eventId);
+          if (cancelled) return;
+
+          if (!draft) {
+            setEvent(undefined);
+            router.push('/lite/create');
+            return;
+          }
+
+          const activeDraft =
+            draft.status === 'draft' ? { ...draft, status: 'active' as const } : draft;
+
+          if (activeDraft !== draft) {
+            await saveLiteEvent(activeDraft);
+          }
+
+          const normalizedEvent = normalizeLiteDraftToEvent(activeDraft);
+          setEvent((prev) => {
+            if (!isEqual(prev, normalizedEvent)) {
+              return normalizedEvent;
+            }
+            return prev;
+          });
+          setPostAssignments(normalizedEvent.postAssignments || {});
+        } catch (error) {
+          console.error('Error loading local event:', error);
+          setEvent(undefined);
+          router.push('/lite/create');
+        }
+      };
+
+      void loadLiteEvent();
+      return () => {
+        cancelled = true;
+      };
+    }
+
     if (!user) {
       return;
     }
-    
+
     const unsubscribe = onSnapshot(doc(db, 'events', eventId), (doc) => {
       if (doc.exists()) {
         const eventData = doc.data() as Event;
@@ -1647,9 +1788,9 @@ export default function DispatchPage({ params }: DispatchPageProps) {
         router.push('/?login=true&error=unauthorized');
       }
     });
-    
+
     return () => unsubscribe();
-  }, [eventId, user, router, isAdmin]);
+  }, [eventId, user, router, isAdmin, isLiteMode]);
   
   const handleRemoveTeamFromCall = async (callId: string, teamToRemove: string) => {
     if (!event) return;
@@ -2667,7 +2808,73 @@ export default function DispatchPage({ params }: DispatchPageProps) {
       draggable: true,
       transition: Slide,
     });
-  }  
+  }
+
+  const formatSummaryTimestamp = useCallback((timestamp: number): string => {
+    return Number.isFinite(timestamp) ? timestamp.toFixed(2) : '';
+  }, []);
+
+  const generateSummaryCSVData = useCallback((): string => {
+    if (!event) return '';
+
+    const csvRows: string[] = [];
+    csvRows.push('Log Type,Team/Call ID,Timestamp,Message');
+
+    event.staff.forEach((team) => {
+      (team.log || []).forEach((entry: TeamLogEntry) => {
+        const message = (entry.message || '').replace(/"/g, '""');
+        csvRows.push(`Staff,${team.team},${formatSummaryTimestamp(entry.timestamp)},"${message}"`);
+      });
+    });
+
+    event.calls.forEach((call) => {
+      (call.log || []).forEach((entry: CallLogEntry) => {
+        const message = (entry.message || '').replace(/"/g, '""');
+        csvRows.push(`Call,${call.id},${formatSummaryTimestamp(entry.timestamp)},"${message}"`);
+      });
+    });
+
+    return csvRows.join('\n');
+  }, [event, formatSummaryTimestamp]);
+
+  const handleExportSummaryCsv = useCallback(() => {
+    const csvContent = generateSummaryCSVData();
+    if (!csvContent) {
+      toast.info('No summary logs to export yet.');
+      return;
+    }
+
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.setAttribute('download', `${event?.name || eventId || 'LiteEvent'}_Summary.csv`);
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [event?.name, eventId, generateSummaryCSVData]);
+
+  const handleClearLiteEvent = useCallback(async () => {
+    if (!isLiteMode || !eventId) return;
+
+    const confirmed = window.confirm(
+      'This will permanently clear this local event and all logs. This action is irreversible. Are you sure you want to continue?'
+    );
+
+    if (!confirmed) return;
+
+    try {
+      await deleteLiteEvent(eventId);
+      toast.success('Local event cleared.');
+      router.push('/lite');
+    } catch (error) {
+      console.error('Failed to clear local event:', error);
+      toast.error('Failed to clear local event. Please try again.');
+    }
+  }, [isLiteMode, eventId, router]);
+
   const [showVenueMap, setShowVenueMap] = useState(false);
   const [showPostingSchedule, setShowPostingSchedule] = useState(false);
   const [showEndEvent, setShowEndEvent] = useState(false);
@@ -2676,17 +2883,33 @@ export default function DispatchPage({ params }: DispatchPageProps) {
     const openVenue = () => setShowVenueMap(true);
     const openPosting = () => setShowPostingSchedule(true);
     const openEnd = () => setShowEndEvent(true);
+    const openLiteClear = () => {
+      void handleClearLiteEvent();
+    };
+    const openLiteExport = () => {
+      handleExportSummaryCsv();
+    };
 
-    window.addEventListener('open-venue-map', openVenue);
     window.addEventListener('open-posting-schedule', openPosting);
-    window.addEventListener('open-end-event', openEnd);
+    window.addEventListener('open-lite-clear-event', openLiteClear);
+    window.addEventListener('open-lite-export-summary', openLiteExport);
+
+    if (!isLiteMode) {
+      window.addEventListener('open-venue-map', openVenue);
+      window.addEventListener('open-end-event', openEnd);
+    }
 
     return () => {
-      window.removeEventListener('open-venue-map', openVenue);
       window.removeEventListener('open-posting-schedule', openPosting);
-      window.removeEventListener('open-end-event', openEnd);
+      window.removeEventListener('open-lite-clear-event', openLiteClear);
+      window.removeEventListener('open-lite-export-summary', openLiteExport);
+
+      if (!isLiteMode) {
+        window.removeEventListener('open-venue-map', openVenue);
+        window.removeEventListener('open-end-event', openEnd);
+      }
     };
-  }, []);
+  }, [isLiteMode, handleClearLiteEvent, handleExportSummaryCsv]);
 
   // Tab cycling for left sidebar tabs
   useEffect(() => {
@@ -2711,19 +2934,21 @@ export default function DispatchPage({ params }: DispatchPageProps) {
   }, [selectedLeftTab]);
 
   useEffect(() => {
+    if (isLiteMode) return;
+
     if (ready && !user) {
       // Store the current path for redirect after login
       sessionStorage.setItem('redirectPath', `/events/${eventId}/dispatch`);
       router.push('/?login=true&error=auth');
     }
-  }, [user, ready, router, eventId]);
+  }, [user, ready, router, eventId, isLiteMode]);
 
   // Return early if auth is not ready or user is not authenticated
-  if (!ready) {
+  if (!isLiteMode && !ready) {
     return <LoadingScreen label="Loading…" />;
   }
 
-  if (!user) {
+  if (!isLiteMode && !user) {
     return (
       <div className="w-full bg-surface-deepest min-h-[calc(100vh-72px)] flex items-center justify-center">
         <div className="text-surface-light">Redirecting...</div>
@@ -2932,6 +3157,8 @@ export default function DispatchPage({ params }: DispatchPageProps) {
       {/* Main Layout */}
       <div className="w-full bg-surface-deepest h-[calc(100vh-72px)]">
         <div className="max-w-[1750px] mx-auto px-3 sm:px-4 h-full">
+
+
           {isAdmin && (
             <button 
               onClick={() => setShowDebugModal(true)}
@@ -3905,32 +4132,6 @@ export default function DispatchPage({ params }: DispatchPageProps) {
         </div>
       </div>
 
-      {/* All your existing modals - unchanged */}
-      {event?.venue && (
-        <VenueMapModal
-          isOpen={showVenueMap}
-          onClose={() => setShowVenueMap(false)}
-          layers={
-            event.venue.layers && event.venue.layers.length
-              ? event.venue.layers
-              : [
-                  {
-                    id:
-                      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-                        ? (crypto as unknown as { randomUUID?: () => string }).randomUUID?.() ?? `layer-${Date.now()}`
-                        : `layer-${Date.now()}`,
-                    name: event.venue.name || 'Main Floor',
-                    posts: event.eventPosts || [],
-                    mapUrl: event.venue.mapUrl,
-                  },
-                ]
-          }
-          staff={event.staff || []}
-          equipment={event.eventEquipment || []}
-          teamTimers={teamTimers}
-        />
-      )}
-
       <PostingScheduleModal
         isOpen={showPostingSchedule}
         onClose={() => setShowPostingSchedule(false)}
@@ -3945,12 +4146,42 @@ export default function DispatchPage({ params }: DispatchPageProps) {
         notifyPostAssignmentChange={notifyPostAssignmentChange}
       />
 
-      <EndEventModal
-        open={showEndEvent}
-        onClose={() => setShowEndEvent(false)}
-        onEndNoSummary={async () => {}}
-        onQuickSummary={async () => router.push(`/events/${event.id}/summary`)}
-      />
+      {!isLiteMode && (
+        <>
+          {/* Cloud-only modals */}
+          {event?.venue && (
+            <VenueMapModal
+              isOpen={showVenueMap}
+              onClose={() => setShowVenueMap(false)}
+              layers={
+                event.venue.layers && event.venue.layers.length
+                  ? event.venue.layers
+                  : [
+                      {
+                        id:
+                          typeof crypto !== 'undefined' && 'randomUUID' in crypto
+                            ? (crypto as unknown as { randomUUID?: () => string }).randomUUID?.() ?? `layer-${Date.now()}`
+                            : `layer-${Date.now()}`,
+                        name: event.venue.name || 'Main Floor',
+                        posts: event.eventPosts || [],
+                        mapUrl: event.venue.mapUrl,
+                      },
+                    ]
+              }
+              staff={event.staff || []}
+              equipment={event.eventEquipment || []}
+              teamTimers={teamTimers}
+            />
+          )}
+
+          <EndEventModal
+            open={showEndEvent}
+            onClose={() => setShowEndEvent(false)}
+            onEndNoSummary={async () => {}}
+            onQuickSummary={async () => router.push(`/events/${event.id}/summary`)}
+          />
+        </>
+      )}
 
       {showDuplicateModal && selectedDuplicateCallId && (
         <div className="fixed inset-0 bg-black bg-opacity-60 z-[100] flex items-center justify-center" onClick={() => setShowDuplicateModal(false)}>

--- a/src/app/(main)/venues/management/page.client.tsx
+++ b/src/app/(main)/venues/management/page.client.tsx
@@ -22,8 +22,6 @@ import LocationEditModal from '@/components/modals/venue/locationedit';
 import {
   Button,
   Input,
-  Select,
-  SelectItem,
   ButtonGroup,
   Card,
   Tabs,
@@ -120,7 +118,7 @@ export default function VenueManagementPageClient() {
   const [hoverId, setHoverId] = useState<number | null>(null);
 
   // Image aspect ratio
-  const [aspectRatio, setAspectRatio] = useState(1);
+  const [, setAspectRatio] = useState(1);
 
   // New layer modal
   const [isNewLayerModalOpen, setIsNewLayerModalOpen] = useState(false);
@@ -249,14 +247,6 @@ export default function VenueManagementPageClient() {
       ...prev,
       equipment: prev.equipment.filter((_, i) => i !== index),
     }));
-  };
-
-  const updateEquipmentLocation = (index: number, locationId: string) => {
-    setVenueData((prev) => {
-      const updated = [...prev.equipment];
-      updated[index] = { ...updated[index], locationId: locationId || undefined };
-      return { ...prev, equipment: updated };
-    });
   };
 
   const startEditEquipment = (index: number) => {

--- a/src/app/(main)/venues/selection/page.tsx
+++ b/src/app/(main)/venues/selection/page.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useState, useMemo } from 'react';
 import { db } from '@/app/firebase';
 import { collection, getDocs, query, where, deleteDoc, doc, addDoc, onSnapshot, Unsubscribe } from 'firebase/firestore';
-import { getAuth } from 'firebase/auth';
 import type { Venue, Event } from '@/app/types';
 import { useAuth } from '@/hooks/useauth';
 import LoadingScreen from '@/components/ui/loading-screen';

--- a/src/app/events.d.ts
+++ b/src/app/events.d.ts
@@ -5,5 +5,7 @@ declare global {
     'open-venue-map': CustomEvent<void>;
     'open-posting-schedule': CustomEvent<void>;
     'open-end-event': CustomEvent<void>;
+    'open-lite-clear-event': CustomEvent<void>;
+    'open-lite-export-summary': CustomEvent<void>;
   }
 }

--- a/src/app/lite/create/page.tsx
+++ b/src/app/lite/create/page.tsx
@@ -1,0 +1,1470 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  Button,
+  Card,
+  Checkbox,
+  Chip,
+  DatePicker,
+  Input,
+  ScrollShadow,
+  Select,
+  SelectItem,
+  Tab,
+  Tabs,
+  TimeInput,
+} from '@heroui/react';
+import { getLocalTimeZone, parseDate, Time, today } from '@internationalized/date';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { Edit2, Plus, Trash2 } from 'lucide-react';
+import type { Post, Staff, Supervisor, Equipment } from '@/app/types';
+import LoadingScreen from '@/components/ui/loading-screen';
+import { DiagonalStreaksFixed } from '@/components/ui/diagonal-streaks-fixed';
+import AddTeamModal from '@/components/modals/event/addteammodal';
+import AddSupervisorModal from '@/components/modals/event/addsupervisormodal';
+import {
+  createDefaultLiteEventDraft,
+  generateLiteEventId,
+  getLiteEvent,
+  type LiteEventDraft,
+  saveLiteEvent,
+} from '@/lib/liteEventStore';
+
+const LICENSES = ['CPR', 'EMT-B', 'EMT-A', 'EMT-P', 'RN', 'MD/DO'];
+
+type TeamMemberDraft = { name: string; cert: string; lead: boolean };
+
+type ScheduleChip = {
+  id: string;
+  time: string;
+};
+
+const makeId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const getPostName = (post: Post): string =>
+  typeof post === 'string' ? post : post.name;
+
+const setPostName = (post: Post, name: string): Post =>
+  typeof post === 'string' ? { name, x: null, y: null } : { ...post, name };
+
+const parseTimeValue = (value: string, fallback: Time): Time => {
+  const [hourRaw, minuteRaw] = value.split(':');
+  const hour = Number(hourRaw);
+  const minute = Number(minuteRaw);
+
+  if (
+    Number.isInteger(hour) &&
+    Number.isInteger(minute) &&
+    hour >= 0 &&
+    hour <= 23 &&
+    minute >= 0 &&
+    minute <= 59
+  ) {
+    return new Time(hour, minute);
+  }
+
+  return fallback;
+};
+
+const formatTimeValue = (value: Time) =>
+  `${value.hour.toString().padStart(2, '0')}:${value.minute.toString().padStart(2, '0')}`;
+
+const buildPostingTimes = (from: Time, to: Time, byMinutesRaw: string): string[] => {
+  const byMinutes = Number.parseInt(byMinutesRaw, 10);
+  if (!Number.isFinite(byMinutes) || byMinutes <= 0) return [];
+
+  const minutesInDay = 24 * 60;
+  const startMinutes = from.hour * 60 + from.minute;
+  const toMinutes = to.hour * 60 + to.minute;
+  const endMinutes = toMinutes <= startMinutes ? toMinutes + minutesInDay : toMinutes;
+
+  const times: string[] = [];
+  const maxIterations = Math.ceil((endMinutes - startMinutes) / Math.max(1, byMinutes)) + 2;
+  let iteration = 0;
+
+  for (let value = startMinutes; value <= endMinutes; value += byMinutes) {
+    iteration += 1;
+    if (iteration > maxIterations) break;
+
+    const normalized = value % minutesInDay;
+    const hour = Math.floor(normalized / 60);
+    const minute = normalized % 60;
+    times.push(`${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`);
+  }
+
+  return times;
+};
+
+export default function LiteCreatePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const requestedEventId = searchParams.get('eventId');
+
+  const [loading, setLoading] = useState(true);
+  const [eventDraft, setEventDraft] = useState<LiteEventDraft | null>(null);
+
+  const [selectedLeftTab, setSelectedLeftTab] = useState<'locations' | 'equipment'>('locations');
+  const [selectedRightTab, setSelectedRightTab] = useState<
+    'teams' | 'supervisors' | 'posts' | 'equipment'
+  >('teams');
+
+  const [locationInput, setLocationInput] = useState('');
+  const [editingLocationIndex, setEditingLocationIndex] = useState<number | null>(null);
+  const [locationEditInput, setLocationEditInput] = useState('');
+
+  const [equipmentInput, setEquipmentInput] = useState('');
+  const [editingEquipmentIndex, setEditingEquipmentIndex] = useState<number | null>(null);
+  const [equipmentEditInput, setEquipmentEditInput] = useState('');
+
+  const [isTeamModalOpen, setIsTeamModalOpen] = useState(false);
+  const [teamModalMode, setTeamModalMode] = useState<'create' | 'edit'>('create');
+  const [editingTeamIndex, setEditingTeamIndex] = useState<number | null>(null);
+  const [teamName, setTeamName] = useState('');
+  const [memberName, setMemberName] = useState('');
+  const [memberCert, setMemberCert] = useState('');
+  const [isTeamLead, setIsTeamLead] = useState(false);
+  const [currentMembers, setCurrentMembers] = useState<TeamMemberDraft[]>([]);
+  const [openTeams, setOpenTeams] = useState<Record<number, boolean>>({});
+
+  const [isSupervisorModalOpen, setIsSupervisorModalOpen] = useState(false);
+  const [samName, setSamName] = useState('');
+  const [samMemberName, setSamMemberName] = useState('');
+  const [samCert, setSamCert] = useState('');
+  const [openSupervisors, setOpenSupervisors] = useState<Record<number, boolean>>({});
+
+  const [postsEnabled, setPostsEnabled] = useState(true);
+
+  const [scheduleFrom, setScheduleFrom] = useState<Time>(new Time(16, 0));
+  const [scheduleTo, setScheduleTo] = useState<Time>(new Time(23, 59));
+  const [scheduleBy, setScheduleBy] = useState('75');
+  const [scheduleChips, setScheduleChips] = useState<ScheduleChip[]>([]);
+  const [editingChipId, setEditingChipId] = useState<string | null>(null);
+  const [editingChipValue, setEditingChipValue] = useState('');
+
+  const initializedScheduleRef = useRef<string | null>(null);
+
+  const allPosts = useMemo(() => eventDraft?.venue.posts ?? [], [eventDraft?.venue.posts]);
+
+  const inputClassNames = {
+    label: 'text-white font-medium',
+    inputWrapper:
+      'rounded-2xl px-4 hover:bg-surface-deep shadow-none group-data-[focus-visible=true]:ring-0 group-data-[focus-visible=true]:ring-offset-0',
+    input:
+      'text-white outline-none focus:outline-none data-[focus=true]:outline-none focus:ring-0 focus-visible:ring-0',
+  } as const;
+
+  const selectClassNames = {
+    label: 'text-white font-medium',
+    input: 'text-white text-sm outline-none focus:outline-none data-[focus=true]:outline-none',
+    inputWrapper:
+      'rounded-2xl px-4 pr-6 hover:bg-surface-deep shadow-none group-data-[focus-visible=true]:ring-0 group-data-[focus-visible=true]:ring-offset-0',
+  } as const;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const initialize = async () => {
+      const resolvedEventId = requestedEventId?.trim() || generateLiteEventId();
+
+      if (!requestedEventId) {
+        router.replace(`/lite/create?eventId=${resolvedEventId}`);
+      }
+
+      let existing = await getLiteEvent(resolvedEventId);
+
+      if (!existing) {
+        let seededName = '';
+        if (typeof window !== 'undefined') {
+          const seedRaw = sessionStorage.getItem(`lite_event_${resolvedEventId}`);
+          if (seedRaw) {
+            try {
+              const parsed = JSON.parse(seedRaw) as { name?: string };
+              seededName = parsed?.name?.trim() ?? '';
+            } catch {
+              seededName = '';
+            }
+          }
+        }
+
+        existing = createDefaultLiteEventDraft(resolvedEventId, seededName);
+        await saveLiteEvent(existing);
+      }
+
+      if (cancelled) return;
+      setEventDraft(existing);
+      setLoading(false);
+    };
+
+    void initialize();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [requestedEventId, router]);
+
+  useEffect(() => {
+    if (!eventDraft) return;
+
+    if (initializedScheduleRef.current === eventDraft.id) return;
+
+    const from = parseTimeValue(eventDraft.scheduleConfig.from, new Time(16, 0));
+    const to = parseTimeValue(eventDraft.scheduleConfig.to, new Time(23, 59));
+
+    setScheduleFrom(from);
+    setScheduleTo(to);
+    setScheduleBy(eventDraft.scheduleConfig.by || '75');
+
+    if (eventDraft.postingTimes.length > 0) {
+      setScheduleChips(
+        eventDraft.postingTimes.map((time) => ({
+          id: makeId(),
+          time,
+        }))
+      );
+    } else {
+      setScheduleChips([]);
+    }
+
+    initializedScheduleRef.current = eventDraft.id;
+  }, [eventDraft]);
+
+  useEffect(() => {
+    if (!eventDraft) return;
+
+    const timeout = window.setTimeout(() => {
+      void saveLiteEvent(eventDraft);
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [eventDraft]);
+
+  const updateDraft = (updater: (current: LiteEventDraft) => LiteEventDraft) => {
+    setEventDraft((current) => (current ? updater(current) : current));
+  };
+
+  const addLocation = () => {
+    const name = locationInput.trim();
+    if (!name) return;
+
+    updateDraft((current) => {
+      const duplicate = current.venue.posts.some(
+        (post) => getPostName(post).toLowerCase() === name.toLowerCase()
+      );
+      if (duplicate) return current;
+
+      const nextPost: Post = { name, x: null, y: null };
+      return {
+        ...current,
+        venue: {
+          ...current.venue,
+          posts: [...current.venue.posts, nextPost],
+        },
+      };
+    });
+
+    setLocationInput('');
+  };
+
+  const removeLocation = (index: number) => {
+    updateDraft((current) => {
+      const target = current.venue.posts[index];
+      if (!target) return current;
+
+      const removedName = getPostName(target);
+      return {
+        ...current,
+        venue: {
+          ...current.venue,
+          posts: current.venue.posts.filter((_, idx) => idx !== index),
+        },
+        eventPosts: current.eventPosts.filter((post) => getPostName(post) !== removedName),
+        eventEquipment: current.eventEquipment.map((item) =>
+          item.defaultLocation === removedName
+            ? { ...item, defaultLocation: undefined }
+            : item
+        ),
+      };
+    });
+
+    if (editingLocationIndex === index) {
+      setEditingLocationIndex(null);
+      setLocationEditInput('');
+    }
+  };
+
+  const startLocationEdit = (index: number) => {
+    const post = allPosts[index];
+    if (!post) return;
+    setEditingLocationIndex(index);
+    setLocationEditInput(getPostName(post));
+  };
+
+  const saveLocationEdit = () => {
+    if (editingLocationIndex === null) return;
+
+    const nextName = locationEditInput.trim();
+    if (!nextName) return;
+
+    updateDraft((current) => {
+      const existingPost = current.venue.posts[editingLocationIndex];
+      if (!existingPost) return current;
+
+      const oldName = getPostName(existingPost);
+      const duplicate = current.venue.posts.some(
+        (post, idx) => idx !== editingLocationIndex && getPostName(post).toLowerCase() === nextName.toLowerCase()
+      );
+      if (duplicate) return current;
+
+      const nextPosts = [...current.venue.posts];
+      nextPosts[editingLocationIndex] = setPostName(existingPost, nextName);
+
+      return {
+        ...current,
+        venue: {
+          ...current.venue,
+          posts: nextPosts,
+        },
+        eventPosts: current.eventPosts.map((post) =>
+          getPostName(post) === oldName ? setPostName(post, nextName) : post
+        ),
+        eventEquipment: current.eventEquipment.map((item) =>
+          item.defaultLocation === oldName
+            ? { ...item, defaultLocation: nextName }
+            : item
+        ),
+      };
+    });
+
+    setEditingLocationIndex(null);
+    setLocationEditInput('');
+  };
+
+  const cancelLocationEdit = () => {
+    setEditingLocationIndex(null);
+    setLocationEditInput('');
+  };
+
+  const addEquipment = () => {
+    const name = equipmentInput.trim();
+    if (!name) return;
+
+    updateDraft((current) => {
+      const duplicate = current.venue.equipment.some(
+        (equipment) => equipment.name.toLowerCase() === name.toLowerCase()
+      );
+      if (duplicate) return current;
+
+      const nextEquipment: Equipment = {
+        id: makeId(),
+        name,
+        status: 'Available',
+      };
+
+      return {
+        ...current,
+        venue: {
+          ...current.venue,
+          equipment: [...current.venue.equipment, nextEquipment],
+        },
+      };
+    });
+
+    setEquipmentInput('');
+  };
+
+  const removeEquipment = (index: number) => {
+    updateDraft((current) => {
+      const item = current.venue.equipment[index];
+      if (!item) return current;
+
+      return {
+        ...current,
+        venue: {
+          ...current.venue,
+          equipment: current.venue.equipment.filter((_, idx) => idx !== index),
+        },
+        eventEquipment: current.eventEquipment.filter((eq) => eq.id !== item.id),
+      };
+    });
+
+    if (editingEquipmentIndex === index) {
+      setEditingEquipmentIndex(null);
+      setEquipmentEditInput('');
+    }
+  };
+
+  const startEquipmentEdit = (index: number) => {
+    const item = eventDraft?.venue.equipment[index];
+    if (!item) return;
+
+    setEditingEquipmentIndex(index);
+    setEquipmentEditInput(item.name);
+  };
+
+  const saveEquipmentEdit = () => {
+    if (editingEquipmentIndex === null) return;
+
+    const nextName = equipmentEditInput.trim();
+    if (!nextName) return;
+
+    updateDraft((current) => {
+      const existing = current.venue.equipment[editingEquipmentIndex];
+      if (!existing) return current;
+
+      const duplicate = current.venue.equipment.some(
+        (equipment, idx) =>
+          idx !== editingEquipmentIndex && equipment.name.toLowerCase() === nextName.toLowerCase()
+      );
+      if (duplicate) return current;
+
+      const nextEquipment = [...current.venue.equipment];
+      nextEquipment[editingEquipmentIndex] = { ...existing, name: nextName };
+
+      return {
+        ...current,
+        venue: {
+          ...current.venue,
+          equipment: nextEquipment,
+        },
+        eventEquipment: current.eventEquipment.map((equipment) =>
+          equipment.id === existing.id ? { ...equipment, name: nextName } : equipment
+        ),
+      };
+    });
+
+    setEditingEquipmentIndex(null);
+    setEquipmentEditInput('');
+  };
+
+  const cancelEquipmentEdit = () => {
+    setEditingEquipmentIndex(null);
+    setEquipmentEditInput('');
+  };
+
+  const addMember = () => {
+    if (!memberName.trim() || !memberCert) return;
+
+    setCurrentMembers((current) => [
+      ...current,
+      {
+        name: memberName.trim(),
+        cert: memberCert,
+        lead: isTeamLead,
+      },
+    ]);
+
+    setMemberName('');
+    setMemberCert('');
+    setIsTeamLead(false);
+  };
+
+  const removeMember = (index: number) => {
+    setCurrentMembers((current) => current.filter((_, idx) => idx !== index));
+  };
+
+  const handleAddTeam = () => {
+    if (!teamName.trim()) {
+      alert('Please enter a team name.');
+      return;
+    }
+
+    if (currentMembers.length === 0) {
+      alert('A team must have at least one member.');
+      return;
+    }
+
+    updateDraft((current) => {
+      if (teamModalMode === 'edit' && editingTeamIndex !== null) {
+        const existing = current.staff[editingTeamIndex];
+        if (!existing) return current;
+
+        const duplicate = current.staff.some(
+          (staff, idx) =>
+            idx !== editingTeamIndex && staff.team.toLowerCase() === teamName.trim().toLowerCase()
+        );
+        if (duplicate) {
+          alert('Team name already used.');
+          return current;
+        }
+
+        const nextStaff = {
+          ...existing,
+          team: teamName.trim(),
+          members: currentMembers.map(
+            (member) => `${member.name} [${member.cert}]${member.lead ? ' (Lead)' : ''}`
+          ),
+        };
+
+        const nextStaffArray = [...current.staff];
+        nextStaffArray[editingTeamIndex] = nextStaff;
+
+        return {
+          ...current,
+          staff: nextStaffArray,
+        };
+      } else {
+        const duplicate = current.staff.some(
+          (staff) => staff.team.toLowerCase() === teamName.trim().toLowerCase()
+        );
+        if (duplicate) {
+          alert('Team name already used.');
+          return current;
+        }
+
+        const members = currentMembers.map(
+          (member) => `${member.name} [${member.cert}]${member.lead ? ' (Lead)' : ''}`
+        );
+
+        const nextStaff: Staff = {
+          team: teamName.trim(),
+          location: 'No Post',
+          status: 'On Break',
+          members,
+        };
+
+        return {
+          ...current,
+          staff: [...current.staff, nextStaff],
+        };
+      }
+    });
+
+    setTeamName('');
+    setMemberName('');
+    setMemberCert('');
+    setIsTeamLead(false);
+    setCurrentMembers([]);
+    setIsTeamModalOpen(false);
+    setTeamModalMode('create');
+    setEditingTeamIndex(null);
+  };
+
+  const startTeamEdit = (index: number) => {
+    const team = eventDraft?.staff[index];
+    if (!team) return;
+
+    const members = team.members.map((member) => {
+      const match = member.match(/^(.+?)\s*\[([^\]]+)\]\s*(\(Lead\))?$/);
+      if (match) {
+        return {
+          name: match[1],
+          cert: match[2],
+          lead: Boolean(match[3]),
+        };
+      }
+      return { name: member, cert: '', lead: false };
+    });
+
+    setTeamName(team.team);
+    setCurrentMembers(members);
+    setTeamModalMode('edit');
+    setEditingTeamIndex(index);
+    setIsTeamModalOpen(true);
+  };
+
+  const removeTeam = (index: number) => {
+    updateDraft((current) => ({
+      ...current,
+      staff: current.staff.filter((_, idx) => idx !== index),
+    }));
+  };
+
+  const handleAddSupervisor = () => {
+    if (!samName.trim() || !samCert) {
+      alert('Supervisor call sign and certification are required.');
+      return;
+    }
+
+    updateDraft((current) => {
+      const duplicate = current.supervisor.some(
+        (supervisor) => supervisor.team.toLowerCase() === samName.trim().toLowerCase()
+      );
+      if (duplicate) {
+        alert('Supervisor call sign already used.');
+        return current;
+      }
+
+      const nextSupervisor: Supervisor = {
+        team: samName.trim(),
+        location: 'Roaming',
+        status: 'On Break',
+        member: samMemberName.trim()
+          ? `${samMemberName.trim()} [${samCert}]`
+          : `${samName.trim()} [${samCert}]`,
+      };
+
+      return {
+        ...current,
+        supervisor: [...current.supervisor, nextSupervisor],
+      };
+    });
+
+    setSamName('');
+    setSamMemberName('');
+    setSamCert('');
+    setIsSupervisorModalOpen(false);
+  };
+
+  const removeSupervisor = (index: number) => {
+    updateDraft((current) => ({
+      ...current,
+      supervisor: current.supervisor.filter((_, idx) => idx !== index),
+    }));
+  };
+
+  const eventDraftId = eventDraft?.id;
+
+  useEffect(() => {
+    if (!eventDraftId) return;
+
+    const postingTimes = postsEnabled ? buildPostingTimes(scheduleFrom, scheduleTo, scheduleBy) : [];
+
+    setScheduleChips(
+      postingTimes.map((time) => ({
+        id: makeId(),
+        time,
+      }))
+    );
+
+    updateDraft((current) => ({
+      ...current,
+      postingTimes,
+      scheduleConfig: {
+        from: formatTimeValue(scheduleFrom),
+        to: formatTimeValue(scheduleTo),
+        by: scheduleBy,
+      },
+    }));
+  }, [eventDraftId, postsEnabled, scheduleFrom, scheduleTo, scheduleBy]);
+
+  const removeScheduleChip = (chipId: string) => {
+    setScheduleChips((current) => {
+      const filtered = current.filter((chip) => chip.id !== chipId);
+      updateDraft((draft) => ({
+        ...draft,
+        postingTimes: filtered.map((chip) => chip.time),
+      }));
+      return filtered;
+    });
+  };
+
+  const saveEditedScheduleChip = (chipId: string, nextTime: string) => {
+    const trimmed = nextTime.trim();
+    if (!trimmed) {
+      setEditingChipId(null);
+      setEditingChipValue('');
+      return;
+    }
+
+    setScheduleChips((current) => {
+      const updated = current.map((chip) =>
+        chip.id === chipId ? { ...chip, time: trimmed } : chip
+      );
+      updateDraft((draft) => ({
+        ...draft,
+        postingTimes: updated.map((chip) => chip.time),
+      }));
+      return updated;
+    });
+
+    setEditingChipId(null);
+    setEditingChipValue('');
+  };
+
+  const getCalendarDate = () => {
+    const currentDate = eventDraft?.date;
+    if (!currentDate) return today(getLocalTimeZone());
+
+    try {
+      return parseDate(currentDate);
+    } catch {
+      return today(getLocalTimeZone());
+    }
+  };
+
+  const handleCreateLiteEvent = async () => {
+    if (!eventDraft) return;
+
+    if (!eventDraft.name.trim()) {
+      alert('Please enter an event name.');
+      return;
+    }
+
+    const finalized: LiteEventDraft = {
+      ...eventDraft,
+      status: 'active',
+      updatedAt: new Date().toISOString(),
+    };
+
+    await saveLiteEvent(finalized);
+
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem(`lite_event_${eventDraft.id}`);
+    }
+
+    router.push(`/lite/events/${eventDraft.id}/dispatch`);
+  };
+
+  if (loading || !eventDraft) {
+    return <LoadingScreen label="Loading Lite setup…" />;
+  }
+
+  return (
+    <main className="relative bg-surface-deepest text-white h-full overflow-hidden leading-none">
+      <DiagonalStreaksFixed />
+
+      <div className="relative z-10 max-w-[1200px] mx-auto h-full overflow-hidden flex flex-col">
+        <div className="px-6 pt-4 pb-4 flex-shrink-0 space-y-4">
+          <div>
+            <h1 className="text-2xl md:text-3xl font-bold text-white text-left">Lite Event Setup</h1>
+            <p className="text-sm text-surface-light mt-1">
+              Build your event locally with locations, staffing, posts, and schedule before dispatch.
+            </p>
+          </div>
+
+          <div className="flex items-end gap-4">
+            <div style={{ flex: 4 }}>
+              <Input
+                label="Event Name"
+                labelPlacement="outside"
+                placeholder="Enter event name"
+                value={eventDraft.name}
+                onValueChange={(value) =>
+                  updateDraft((current) => ({ ...current, name: value }))
+                }
+                classNames={inputClassNames}
+                size="lg"
+              />
+            </div>
+            <div style={{ flex: 3 }}>
+              <DatePicker
+                label="Event Date"
+                labelPlacement="outside"
+                value={getCalendarDate()}
+                onChange={(value) => {
+                  if (!value) return;
+                  updateDraft((current) => ({ ...current, date: value.toString() }));
+                }}
+                classNames={inputClassNames}
+                size="lg"
+              />
+            </div>
+            <div className="flex-shrink-0">
+              <Button
+                onPress={handleCreateLiteEvent}
+                size="lg"
+                radius="lg"
+                className="bg-accent hover:bg-accent/90 text-white"
+              >
+                Create Event
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-hidden">
+          <div className="flex h-full overflow-hidden">
+            <PanelGroup direction="horizontal">
+              <Panel defaultSize={40} minSize={30} maxSize={55}>
+                <div className="flex flex-col h-full relative overflow-hidden px-6 pt-0 pb-4">
+                  <div className="flex-shrink-0 flex items-end gap-3 mb-3">
+                    <Tabs
+                      selectedKey={selectedLeftTab}
+                      onSelectionChange={(key) => setSelectedLeftTab(key as 'locations' | 'equipment')}
+                      classNames={{
+                        tabList: 'p-1 rounded-2xl flex-shrink-0',
+                        tab: 'rounded-2xl px-4 text-white data-[selected=true]:text-white',
+                        panel: 'hidden',
+                        cursor: 'rounded-2xl',
+                      }}
+                    >
+                      <Tab key="locations" title="Locations" />
+                      <Tab key="equipment" title="Equipment" />
+                    </Tabs>
+
+                    <div className="flex-1 flex gap-2">
+                      <Input
+                        placeholder={selectedLeftTab === 'locations' ? 'e.g., Main Entrance' : 'e.g., Gurney 1'}
+                        value={selectedLeftTab === 'locations' ? locationInput : equipmentInput}
+                        onValueChange={(value) => {
+                          if (selectedLeftTab === 'locations') {
+                            setLocationInput(value);
+                          } else {
+                            setEquipmentInput(value);
+                          }
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault();
+                            if (selectedLeftTab === 'locations') {
+                              addLocation();
+                            } else {
+                              addEquipment();
+                            }
+                          }
+                        }}
+                        variant="flat"
+                        classNames={inputClassNames}
+                      />
+                      <Button
+                        isIconOnly
+                        onPress={selectedLeftTab === 'locations' ? addLocation : addEquipment}
+                        className="flex-shrink-0 bg-accent hover:bg-accent/90 text-white"
+                      >
+                        <Plus className="h-5 w-5" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  <Card
+                    isBlurred
+                    className="flex-1 overflow-hidden"
+                    style={{ backgroundColor: 'rgba(39, 39, 42, 0.5)' }}
+                  >
+                    {selectedLeftTab === 'locations' ? (
+                      <ScrollShadow
+                        hideScrollBar
+                        className="space-y-2 p-3 pr-2 scrollbar-hide h-full"
+                        style={{ minHeight: 0 }}
+                      >
+                        {allPosts.map((post, index) => (
+                          <Card
+                            key={`${getPostName(post)}_${index}`}
+                            isBlurred
+                            className="rounded-2xl"
+                            style={{ backgroundColor: '#27272a' }}
+                          >
+                            <div className="flex items-center justify-between px-3 py-2 gap-2">
+                              {editingLocationIndex === index ? (
+                                <>
+                                  <Input
+                                    value={locationEditInput}
+                                    onValueChange={setLocationEditInput}
+                                    onKeyDown={(event) => {
+                                      if (event.key === 'Enter') {
+                                        event.preventDefault();
+                                        saveLocationEdit();
+                                      }
+                                      if (event.key === 'Escape') {
+                                        event.preventDefault();
+                                        cancelLocationEdit();
+                                      }
+                                    }}
+                                    size="sm"
+                                    autoFocus
+                                    classNames={inputClassNames}
+                                  />
+                                  <div className="flex items-center gap-1">
+                                    <Button isIconOnly size="sm" variant="light" onPress={saveLocationEdit}>
+                                      <Edit2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button isIconOnly size="sm" variant="light" onPress={cancelLocationEdit}>
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </div>
+                                </>
+                              ) : (
+                                <>
+                                  <span className="text-sm text-white truncate">{getPostName(post)}</span>
+                                  <div className="flex items-center gap-1">
+                                    <Button
+                                      isIconOnly
+                                      size="sm"
+                                      variant="light"
+                                      onPress={() => startLocationEdit(index)}
+                                    >
+                                      <Edit2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button
+                                      isIconOnly
+                                      size="sm"
+                                      variant="light"
+                                      color="danger"
+                                      onPress={() => removeLocation(index)}
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                          </Card>
+                        ))}
+                      </ScrollShadow>
+                    ) : (
+                      <ScrollShadow
+                        hideScrollBar
+                        className="space-y-2 p-3 pr-2 scrollbar-hide h-full"
+                        style={{ minHeight: 0 }}
+                      >
+                        {eventDraft.venue.equipment.map((item, index) => (
+                          <Card
+                            key={item.id}
+                            isBlurred
+                            className="rounded-2xl"
+                            style={{ backgroundColor: '#27272a' }}
+                          >
+                            <div className="flex items-center justify-between px-3 py-2 gap-2">
+                              {editingEquipmentIndex === index ? (
+                                <>
+                                  <Input
+                                    value={equipmentEditInput}
+                                    onValueChange={setEquipmentEditInput}
+                                    onKeyDown={(event) => {
+                                      if (event.key === 'Enter') {
+                                        event.preventDefault();
+                                        saveEquipmentEdit();
+                                      }
+                                      if (event.key === 'Escape') {
+                                        event.preventDefault();
+                                        cancelEquipmentEdit();
+                                      }
+                                    }}
+                                    size="sm"
+                                    autoFocus
+                                    classNames={inputClassNames}
+                                  />
+                                  <div className="flex items-center gap-1">
+                                    <Button isIconOnly size="sm" variant="light" onPress={saveEquipmentEdit}>
+                                      <Edit2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button isIconOnly size="sm" variant="light" onPress={cancelEquipmentEdit}>
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </div>
+                                </>
+                              ) : (
+                                <>
+                                  <span className="text-sm text-white truncate">{item.name}</span>
+                                  <div className="flex items-center gap-1">
+                                    <Button
+                                      isIconOnly
+                                      size="sm"
+                                      variant="light"
+                                      onPress={() => startEquipmentEdit(index)}
+                                    >
+                                      <Edit2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button
+                                      isIconOnly
+                                      size="sm"
+                                      variant="light"
+                                      color="danger"
+                                      onPress={() => removeEquipment(index)}
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                          </Card>
+                        ))}
+                      </ScrollShadow>
+                    )}
+                  </Card>
+                </div>
+              </Panel>
+
+              <PanelResizeHandle className="w-1 bg-surface-liner transition-colors cursor-col-resize flex items-center justify-center group">
+                <div className="w-0.5 h-8 bg-surface-light/30 rounded-full transition-colors" />
+              </PanelResizeHandle>
+
+              <Panel defaultSize={60} minSize={45}>
+                <div className="flex flex-col h-full relative overflow-hidden px-6 pt-0 pb-4">
+                  <Card
+                    isBlurred
+                    className="flex-1 flex flex-col overflow-hidden"
+                    style={{ backgroundColor: 'rgba(39, 39, 42, 0.5)' }}
+                  >
+                    <div className="flex-1 flex flex-col h-full overflow-hidden">
+                      <Tabs
+                        selectedKey={selectedRightTab}
+                        onSelectionChange={(key) =>
+                          setSelectedRightTab(key as 'teams' | 'supervisors' | 'posts' | 'equipment')
+                        }
+                        fullWidth
+                        className="w-full flex-shrink-0"
+                        classNames={{
+                          tabList: 'p-1 w-full flex-shrink-0',
+                          tab: 'text-white data-[selected=true]:text-white',
+                          cursor: 'rounded-2xl',
+                          panel: 'hidden',
+                        }}
+                      >
+                        <Tab key="teams" title="Teams" />
+                        <Tab key="supervisors" title="Supervisors" />
+                        <Tab key="posts" title="Posts" />
+                        <Tab key="equipment" title="Equipment" />
+                      </Tabs>
+
+                      <div className="flex-shrink-0 min-h-12 px-3 py-2 flex items-center justify-between border-b border-surface-liner">
+                        {selectedRightTab === 'teams' && (
+                          <>
+                            <h3 className="text-white font-semibold text-lg">Teams</h3>
+                            <Button
+                              isIconOnly
+                              size="sm"
+                              onPress={() => {
+                                setTeamModalMode('create');
+                                setEditingTeamIndex(null);
+                                setTeamName('');
+                                setCurrentMembers([]);
+                                setIsTeamModalOpen(true);
+                              }}
+                              className="min-w-8 w-8 h-8"
+                              style={{ backgroundColor: '#27272a' }}
+                            >
+                              <Plus className="h-4 w-4 text-white" />
+                            </Button>
+                          </>
+                        )}
+
+                        {selectedRightTab === 'supervisors' && (
+                          <>
+                            <h3 className="text-white font-semibold text-lg">Supervisors</h3>
+                            <Button
+                              isIconOnly
+                              size="sm"
+                              onPress={() => setIsSupervisorModalOpen(true)}
+                              className="min-w-8 w-8 h-8"
+                              style={{ backgroundColor: '#27272a' }}
+                            >
+                              <Plus className="h-4 w-4 text-white" />
+                            </Button>
+                          </>
+                        )}
+
+                        {selectedRightTab === 'posts' && (
+                          <>
+                            <h3 className="text-white font-semibold text-lg">Posts</h3>
+                            <div className="h-8 flex items-center">
+                              <Checkbox
+                                isSelected={postsEnabled}
+                                onValueChange={setPostsEnabled}
+                                size="sm"
+                              >
+                                <span className="text-sm text-white">Enable Posts</span>
+                              </Checkbox>
+                            </div>
+                          </>
+                        )}
+
+                        {selectedRightTab === 'equipment' && (
+                          <>
+                            <h3 className="text-white font-semibold text-lg">Equipment</h3>
+                            <div className="w-8 h-8" />
+                          </>
+                        )}
+                      </div>
+
+                      {selectedRightTab === 'teams' && (
+                        <div className="px-4 py-3 flex-1 overflow-hidden">
+                          <ScrollShadow
+                            className="pr-2 scrollbar-hide h-full"
+                            hideScrollBar
+                            style={{ minHeight: 0 }}
+                          >
+                            <div className="grid grid-cols-2 gap-2 auto-rows-max content-start items-start">
+                              {eventDraft.staff.map((staff, index) => (
+                                <Card
+                                  key={`${staff.team}_${index}`}
+                                  isBlurred
+                                  className="rounded-2xl h-fit"
+                                  style={{ backgroundColor: '#27272a' }}
+                                >
+                                  <div className="flex items-center justify-between px-3 py-2 gap-2">
+                                    <button
+                                      type="button"
+                                      className="text-sm text-white truncate text-left flex-1"
+                                      onClick={() =>
+                                        setOpenTeams((current) => ({
+                                          ...current,
+                                          [index]: !current[index],
+                                        }))
+                                      }
+                                    >
+                                      {staff.team}
+                                    </button>
+
+                                    <div className="flex items-center gap-1 flex-shrink-0">
+                                      <Button
+                                        isIconOnly
+                                        size="sm"
+                                        variant="light"
+                                        onPress={() => startTeamEdit(index)}
+                                      >
+                                        <Edit2 className="h-3.5 w-3.5" />
+                                      </Button>
+                                      <Button
+                                        isIconOnly
+                                        size="sm"
+                                        variant="light"
+                                        color="danger"
+                                        onPress={() => removeTeam(index)}
+                                      >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                      </Button>
+                                    </div>
+                                  </div>
+
+                                  {openTeams[index] && (
+                                    <ul className="px-3 pb-2 list-disc list-inside text-xs text-gray-300">
+                                      {staff.members.map((member, memberIndex) => (
+                                        <li key={`${staff.team}_${memberIndex}`}>{member}</li>
+                                      ))}
+                                    </ul>
+                                  )}
+                                </Card>
+                              ))}
+                            </div>
+                          </ScrollShadow>
+                        </div>
+                      )}
+
+                      {selectedRightTab === 'supervisors' && (
+                        <div className="px-4 py-3 flex-1 overflow-hidden">
+                          <ScrollShadow
+                            className="pr-2 scrollbar-hide h-full"
+                            hideScrollBar
+                            style={{ minHeight: 0 }}
+                          >
+                            <div className="grid grid-cols-2 gap-2 auto-rows-max content-start items-start">
+                              {eventDraft.supervisor.map((supervisor, index) => (
+                                <Card
+                                  key={`${supervisor.team}_${index}`}
+                                  isBlurred
+                                  className="rounded-2xl h-fit"
+                                  style={{ backgroundColor: '#27272a' }}
+                                >
+                                  <div className="flex items-center justify-between px-3 py-2 gap-2">
+                                    <button
+                                      type="button"
+                                      className="text-sm text-white truncate text-left flex-1"
+                                      onClick={() =>
+                                        setOpenSupervisors((current) => ({
+                                          ...current,
+                                          [index]: !current[index],
+                                        }))
+                                      }
+                                    >
+                                      {supervisor.team}
+                                    </button>
+
+                                    <Button
+                                      isIconOnly
+                                      size="sm"
+                                      variant="light"
+                                      color="danger"
+                                      onPress={() => removeSupervisor(index)}
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </div>
+
+                                  {openSupervisors[index] && (
+                                    <ul className="px-3 pb-2 list-disc list-inside text-xs text-gray-300">
+                                      <li>{supervisor.member}</li>
+                                    </ul>
+                                  )}
+                                </Card>
+                              ))}
+                            </div>
+                          </ScrollShadow>
+                        </div>
+                      )}
+
+                      {selectedRightTab === 'posts' && (
+                        <div className="px-4 py-3 flex-1 overflow-hidden">
+                          <ScrollShadow
+                            className="space-y-4 pr-2 scrollbar-hide h-full"
+                            hideScrollBar
+                            style={{ minHeight: 0 }}
+                          >
+                            <div className={`space-y-3 ${!postsEnabled ? 'opacity-40 pointer-events-none' : ''}`}>
+                              <Select
+                                label="Select Posts"
+                                labelPlacement="outside"
+                                placeholder="Choose posts for this event"
+                                selectionMode="multiple"
+                                selectedKeys={new Set(eventDraft.eventPosts.map((post) => getPostName(post)))}
+                                isDisabled={!postsEnabled}
+                                classNames={selectClassNames}
+                                size="lg"
+                                onSelectionChange={(keys) => {
+                                  const values =
+                                    keys === 'all'
+                                      ? allPosts.map((post) => getPostName(post))
+                                      : Array.from(keys).map((key) => String(key));
+
+                                  updateDraft((current) => ({
+                                    ...current,
+                                    eventPosts: values
+                                      .map((value) =>
+                                        current.venue.posts.find((post) => getPostName(post) === value)
+                                      )
+                                      .filter((post): post is Post => Boolean(post)),
+                                  }));
+                                }}
+                              >
+                                {allPosts.map((post) => {
+                                  const postName = getPostName(post);
+                                  return (
+                                    <SelectItem key={postName} textValue={postName} aria-label={postName}>
+                                      {postName}
+                                    </SelectItem>
+                                  );
+                                })}
+                              </Select>
+
+                              {eventDraft.eventPosts.length > 0 && (
+                                <div className="flex flex-wrap gap-2">
+                                  {eventDraft.eventPosts.map((post, index) => {
+                                    const postName = getPostName(post);
+                                    return (
+                                      <Chip
+                                        key={`${postName}_${index}`}
+                                        onClose={() => {
+                                          updateDraft((current) => ({
+                                            ...current,
+                                            eventPosts: current.eventPosts.filter((_, idx) => idx !== index),
+                                          }));
+                                        }}
+                                        variant="flat"
+                                        style={{ backgroundColor: '#3eb1fd33', color: '#3eb1fd' }}
+                                      >
+                                        {postName}
+                                      </Chip>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                            </div>
+
+                            <div className={`space-y-3 mt-6 ${!postsEnabled ? 'opacity-40 pointer-events-none' : ''}`}>
+                              <h3 className="text-white font-semibold text-lg">Schedule</h3>
+
+                              <div className="grid grid-cols-3 gap-3">
+                                <TimeInput
+                                  label="From"
+                                  labelPlacement="inside"
+                                  value={scheduleFrom}
+                                  onChange={(value) => value && setScheduleFrom(value)}
+                                  hourCycle={24}
+                                  isDisabled={!postsEnabled}
+                                  classNames={inputClassNames}
+                                  size="md"
+                                />
+                                <TimeInput
+                                  label="To"
+                                  labelPlacement="inside"
+                                  value={scheduleTo}
+                                  onChange={(value) => value && setScheduleTo(value)}
+                                  hourCycle={24}
+                                  isDisabled={!postsEnabled}
+                                  classNames={inputClassNames}
+                                  size="md"
+                                />
+                                <Input
+                                  label="By"
+                                  labelPlacement="inside"
+                                  placeholder="75"
+                                  value={scheduleBy}
+                                  onValueChange={setScheduleBy}
+                                  type="number"
+                                  min="1"
+                                  endContent="min"
+                                  isDisabled={!postsEnabled}
+                                  classNames={inputClassNames}
+                                  size="md"
+                                />
+                              </div>
+
+                              {scheduleChips.length > 0 && (
+                                <div className="flex flex-wrap gap-2 mt-4">
+                                  {scheduleChips.map((chip) => (
+                                    <Chip
+                                      key={chip.id}
+                                      onClose={() => removeScheduleChip(chip.id)}
+                                      variant="flat"
+                                      style={{ backgroundColor: '#3eb1fd33', color: '#3eb1fd' }}
+                                      onClick={() => {
+                                        setEditingChipId(chip.id);
+                                        setEditingChipValue(chip.time);
+                                      }}
+                                      className="cursor-pointer"
+                                    >
+                                      {editingChipId === chip.id ? (
+                                        <input
+                                          type="text"
+                                          value={editingChipValue}
+                                          onChange={(event) => setEditingChipValue(event.target.value)}
+                                          onBlur={() => saveEditedScheduleChip(chip.id, editingChipValue)}
+                                          onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                              saveEditedScheduleChip(chip.id, editingChipValue);
+                                            }
+                                            if (event.key === 'Escape') {
+                                              setEditingChipId(null);
+                                              setEditingChipValue('');
+                                            }
+                                          }}
+                                          autoFocus
+                                          className="bg-transparent outline-none w-16 text-center"
+                                        />
+                                      ) : (
+                                        chip.time
+                                      )}
+                                    </Chip>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          </ScrollShadow>
+                        </div>
+                      )}
+
+                      {selectedRightTab === 'equipment' && (
+                        <div className="px-4 py-3 flex-1 overflow-hidden">
+                          <ScrollShadow
+                            className="space-y-2 pr-2 scrollbar-hide h-full"
+                            hideScrollBar
+                            style={{ minHeight: 0 }}
+                          >
+                            {eventDraft.venue.equipment.map((equipment) => {
+                              const selectedEquipment = eventDraft.eventEquipment.find(
+                                (item) => item.id === equipment.id
+                              );
+
+                              return (
+                                <div key={equipment.id} className="rounded-2xl p-3" style={{ backgroundColor: '#27272a' }}>
+                                  <div className="flex items-center gap-3">
+                                    <Checkbox
+                                      isSelected={Boolean(selectedEquipment)}
+                                      onValueChange={(checked) => {
+                                        if (checked) {
+                                          updateDraft((current) => ({
+                                            ...current,
+                                            eventEquipment: [
+                                              ...current.eventEquipment,
+                                              { ...equipment, defaultLocation: undefined },
+                                            ],
+                                          }));
+                                        } else {
+                                          updateDraft((current) => ({
+                                            ...current,
+                                            eventEquipment: current.eventEquipment.filter(
+                                              (item) => item.id !== equipment.id
+                                            ),
+                                          }));
+                                        }
+                                      }}
+                                    />
+
+                                    <span className="text-white font-medium flex-shrink-0">{equipment.name}</span>
+
+                                    {selectedEquipment && (
+                                      <Select
+                                        placeholder="Select Default Location"
+                                        selectedKeys={
+                                          selectedEquipment.defaultLocation
+                                            ? [selectedEquipment.defaultLocation]
+                                            : []
+                                        }
+                                        onSelectionChange={(keys) => {
+                                          const locationName =
+                                            keys === 'all' ? '' : (Array.from(keys)[0] as string | undefined);
+
+                                          updateDraft((current) => ({
+                                            ...current,
+                                            eventEquipment: current.eventEquipment.map((item) =>
+                                              item.id === equipment.id
+                                                ? {
+                                                    ...item,
+                                                    defaultLocation: locationName,
+                                                  }
+                                                : item
+                                            ),
+                                          }));
+                                        }}
+                                        classNames={{
+                                          ...selectClassNames,
+                                          base: 'max-w-[220px]',
+                                        }}
+                                        size="sm"
+                                        className="ml-auto"
+                                      >
+                                        {allPosts.map((post) => {
+                                          const postName = getPostName(post);
+                                          return <SelectItem key={postName}>{postName}</SelectItem>;
+                                        })}
+                                      </Select>
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </ScrollShadow>
+                        </div>
+                      )}
+                    </div>
+                  </Card>
+                </div>
+              </Panel>
+            </PanelGroup>
+          </div>
+        </div>
+      </div>
+
+      <AddTeamModal
+        isOpen={isTeamModalOpen}
+        onClose={() => {
+          setIsTeamModalOpen(false);
+          setTeamModalMode('create');
+          setEditingTeamIndex(null);
+          setTeamName('');
+          setCurrentMembers([]);
+        }}
+        mode={teamModalMode}
+        onSubmit={handleAddTeam}
+        titleOverride={teamModalMode === 'edit' ? 'Edit Team' : 'Add New Team'}
+        submitLabelOverride={teamModalMode === 'edit' ? 'Save Team' : 'Add Team'}
+        teamName={teamName}
+        setTeamName={setTeamName}
+        memberName={memberName}
+        setMemberName={setMemberName}
+        memberCert={memberCert}
+        setMemberCert={setMemberCert}
+        isTeamLead={isTeamLead}
+        setIsTeamLead={setIsTeamLead}
+        addMember={addMember}
+        currentMembers={currentMembers}
+        removeMember={removeMember}
+        LICENSES={LICENSES}
+      />
+
+      <AddSupervisorModal
+        isOpen={isSupervisorModalOpen}
+        onClose={() => setIsSupervisorModalOpen(false)}
+        mode="create"
+        onSubmit={handleAddSupervisor}
+        titleOverride="Add New Supervisor"
+        submitLabelOverride="Add Supervisor"
+        teamName={samName}
+        setTeamName={setSamName}
+        memberName={samMemberName}
+        setMemberName={setSamMemberName}
+        memberCert={samCert}
+        setMemberCert={setSamCert}
+        LICENSES={LICENSES}
+      />
+    </main>
+  );
+}

--- a/src/app/lite/create/page.tsx
+++ b/src/app/lite/create/page.tsx
@@ -1,4 +1,7 @@
-import React, { Suspense } from 'react';
+'use client';
+
+import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   Button,
   Card,
@@ -98,11 +101,6 @@ const buildPostingTimes = (from: Time, to: Time, byMinutesRaw: string): string[]
 
   return times;
 };
-
-'use client';
-
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
 
 function LiteCreateContent() {
   const router = useRouter();

--- a/src/app/lite/create/page.tsx
+++ b/src/app/lite/create/page.tsx
@@ -1,7 +1,4 @@
-'use client';
-
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import React, { Suspense } from 'react';
 import {
   Button,
   Card,
@@ -102,7 +99,12 @@ const buildPostingTimes = (from: Time, to: Time, byMinutesRaw: string): string[]
   return times;
 };
 
-export default function LiteCreatePage() {
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function LiteCreateContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const requestedEventId = searchParams.get('eventId');
@@ -1466,5 +1468,13 @@ export default function LiteCreatePage() {
         LICENSES={LICENSES}
       />
     </main>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <LiteCreateContent />
+    </Suspense>
   );
 }

--- a/src/app/lite/events/[localEventId]/dispatch/page.tsx
+++ b/src/app/lite/events/[localEventId]/dispatch/page.tsx
@@ -1,205 +1,23 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { Button, Card, ScrollShadow, Chip } from '@heroui/react';
-import LoadingScreen from '@/components/ui/loading-screen';
-import { DiagonalStreaksFixed } from '@/components/ui/diagonal-streaks-fixed';
-import { getLiteEvent, type LiteEventDraft } from '@/lib/liteEventStore';
-import type { Post } from '@/app/types';
-
-const getPostName = (post: Post) => (typeof post === 'string' ? post : post.name);
+import { useMemo } from 'react';
+import { useParams } from 'next/navigation';
+import SharedDispatchPage from '@/app/(main)/events/[eventId]/dispatch/page';
 
 export default function LiteDispatchPage() {
   const params = useParams();
-  const router = useRouter();
   const localEventId = String(params?.localEventId ?? '');
 
-  const [loading, setLoading] = useState(true);
-  const [eventDraft, setEventDraft] = useState<LiteEventDraft | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      if (!localEventId) {
-        if (!cancelled) setLoading(false);
-        return;
-      }
-
-      const event = await getLiteEvent(localEventId);
-      if (cancelled) return;
-
-      setEventDraft(event);
-      setLoading(false);
-    };
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [localEventId]);
-
-  const eventPosts = useMemo(
-    () => (eventDraft?.eventPosts ?? []).map((post) => getPostName(post)),
-    [eventDraft?.eventPosts]
+  const sharedParams = useMemo(
+    () => Promise.resolve({ eventId: localEventId }),
+    [localEventId]
   );
 
-  if (loading) {
-    return <LoadingScreen label="Loading Lite dispatch…" />;
-  }
-
-  if (!eventDraft) {
-    return (
-      <main className="relative bg-surface-deepest text-white min-h-[100dvh] px-6 py-10">
-        <DiagonalStreaksFixed />
-        <div className="relative z-10 max-w-[900px] mx-auto">
-          <Card isBlurred className="p-6 bg-transparent border border-default-200">
-            <h1 className="text-2xl font-semibold mb-2">Lite event not found</h1>
-            <p className="text-surface-light mb-6">
-              This local event may have been removed from browser storage.
-            </p>
-            <div className="flex gap-3">
-              <Button
-                className="bg-accent hover:bg-accent/90 text-white"
-                onPress={() => router.push('/lite/create')}
-              >
-                Create New Lite Event
-              </Button>
-              <Button
-                variant="bordered"
-                onPress={() => router.push(`/lite/create?eventId=${localEventId}`)}
-              >
-                Return to Setup
-              </Button>
-            </div>
-          </Card>
-        </div>
-      </main>
-    );
-  }
-
   return (
-    <main className="relative bg-surface-deepest text-white min-h-[100dvh] px-6 py-8 overflow-hidden">
-      <DiagonalStreaksFixed />
-
-      <div className="relative z-10 max-w-[1100px] mx-auto h-full flex flex-col gap-4">
-        <Card isBlurred className="p-5 bg-transparent border border-default-200">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h1 className="text-2xl md:text-3xl font-bold">{eventDraft.name || 'Untitled Lite Event'}</h1>
-              <p className="text-surface-light mt-1">
-                Date: {eventDraft.date} · Event ID: {eventDraft.id}
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="bordered" onPress={() => router.push(`/lite/create?eventId=${eventDraft.id}`)}>
-                Edit Setup
-              </Button>
-              <Button className="bg-accent hover:bg-accent/90 text-white" onPress={() => router.push('/lite')}>
-                Back to Lite Home
-              </Button>
-            </div>
-          </div>
-        </Card>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1 min-h-0">
-          <Card isBlurred className="p-4 bg-transparent border border-default-200 min-h-0">
-            <h2 className="text-lg font-semibold mb-3">Staffing</h2>
-            <ScrollShadow hideScrollBar className="pr-2 h-[40dvh] md:h-[52dvh]">
-              <div className="space-y-3">
-                <div>
-                  <p className="text-sm text-surface-light mb-2">Teams ({eventDraft.staff.length})</p>
-                  {eventDraft.staff.length === 0 ? (
-                    <p className="text-sm text-surface-light/70">No teams added.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {eventDraft.staff.map((team, index) => (
-                        <div key={`${team.team}_${index}`} className="rounded-xl bg-surface-deep px-3 py-2">
-                          <p className="font-medium">{team.team}</p>
-                          <p className="text-xs text-surface-light">{team.members.join(', ')}</p>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                <div>
-                  <p className="text-sm text-surface-light mb-2">Supervisors ({eventDraft.supervisor.length})</p>
-                  {eventDraft.supervisor.length === 0 ? (
-                    <p className="text-sm text-surface-light/70">No supervisors added.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {eventDraft.supervisor.map((supervisor, index) => (
-                        <div key={`${supervisor.team}_${index}`} className="rounded-xl bg-surface-deep px-3 py-2">
-                          <p className="font-medium">{supervisor.team}</p>
-                          <p className="text-xs text-surface-light">{supervisor.member}</p>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </ScrollShadow>
-          </Card>
-
-          <Card isBlurred className="p-4 bg-transparent border border-default-200 min-h-0">
-            <h2 className="text-lg font-semibold mb-3">Posts, Schedule, Equipment</h2>
-            <ScrollShadow hideScrollBar className="pr-2 h-[40dvh] md:h-[52dvh]">
-              <div className="space-y-4">
-                <div>
-                  <p className="text-sm text-surface-light mb-2">Selected Posts ({eventPosts.length})</p>
-                  {eventPosts.length === 0 ? (
-                    <p className="text-sm text-surface-light/70">No posts selected.</p>
-                  ) : (
-                    <div className="flex flex-wrap gap-2">
-                      {eventPosts.map((post) => (
-                        <Chip key={post} variant="flat" style={{ backgroundColor: '#3eb1fd33', color: '#3eb1fd' }}>
-                          {post}
-                        </Chip>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                <div>
-                  <p className="text-sm text-surface-light mb-2">Posting Schedule ({eventDraft.postingTimes.length})</p>
-                  {eventDraft.postingTimes.length === 0 ? (
-                    <p className="text-sm text-surface-light/70">No schedule times configured.</p>
-                  ) : (
-                    <div className="flex flex-wrap gap-2">
-                      {eventDraft.postingTimes.map((time) => (
-                        <Chip key={time} variant="flat" style={{ backgroundColor: '#22c55e33', color: '#22c55e' }}>
-                          {time}
-                        </Chip>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                <div>
-                  <p className="text-sm text-surface-light mb-2">Event Equipment ({eventDraft.eventEquipment.length})</p>
-                  {eventDraft.eventEquipment.length === 0 ? (
-                    <p className="text-sm text-surface-light/70">No equipment selected.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {eventDraft.eventEquipment.map((equipment) => (
-                        <div key={equipment.id} className="rounded-xl bg-surface-deep px-3 py-2 text-sm">
-                          <span>{equipment.name}</span>
-                          {equipment.defaultLocation && (
-                            <span className="text-surface-light ml-2">· {equipment.defaultLocation}</span>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </ScrollShadow>
-          </Card>
-        </div>
-      </div>
-    </main>
+    <SharedDispatchPage
+      params={sharedParams}
+      liteEventId={localEventId}
+      forceLiteMode={true}
+    />
   );
 }

--- a/src/app/lite/events/[localEventId]/dispatch/page.tsx
+++ b/src/app/lite/events/[localEventId]/dispatch/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button, Card, ScrollShadow, Chip } from '@heroui/react';
+import LoadingScreen from '@/components/ui/loading-screen';
+import { DiagonalStreaksFixed } from '@/components/ui/diagonal-streaks-fixed';
+import { getLiteEvent, type LiteEventDraft } from '@/lib/liteEventStore';
+import type { Post } from '@/app/types';
+
+const getPostName = (post: Post) => (typeof post === 'string' ? post : post.name);
+
+export default function LiteDispatchPage() {
+  const params = useParams();
+  const router = useRouter();
+  const localEventId = String(params?.localEventId ?? '');
+
+  const [loading, setLoading] = useState(true);
+  const [eventDraft, setEventDraft] = useState<LiteEventDraft | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      if (!localEventId) {
+        if (!cancelled) setLoading(false);
+        return;
+      }
+
+      const event = await getLiteEvent(localEventId);
+      if (cancelled) return;
+
+      setEventDraft(event);
+      setLoading(false);
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [localEventId]);
+
+  const eventPosts = useMemo(
+    () => (eventDraft?.eventPosts ?? []).map((post) => getPostName(post)),
+    [eventDraft?.eventPosts]
+  );
+
+  if (loading) {
+    return <LoadingScreen label="Loading Lite dispatch…" />;
+  }
+
+  if (!eventDraft) {
+    return (
+      <main className="relative bg-surface-deepest text-white min-h-[100dvh] px-6 py-10">
+        <DiagonalStreaksFixed />
+        <div className="relative z-10 max-w-[900px] mx-auto">
+          <Card isBlurred className="p-6 bg-transparent border border-default-200">
+            <h1 className="text-2xl font-semibold mb-2">Lite event not found</h1>
+            <p className="text-surface-light mb-6">
+              This local event may have been removed from browser storage.
+            </p>
+            <div className="flex gap-3">
+              <Button
+                className="bg-accent hover:bg-accent/90 text-white"
+                onPress={() => router.push('/lite/create')}
+              >
+                Create New Lite Event
+              </Button>
+              <Button
+                variant="bordered"
+                onPress={() => router.push(`/lite/create?eventId=${localEventId}`)}
+              >
+                Return to Setup
+              </Button>
+            </div>
+          </Card>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="relative bg-surface-deepest text-white min-h-[100dvh] px-6 py-8 overflow-hidden">
+      <DiagonalStreaksFixed />
+
+      <div className="relative z-10 max-w-[1100px] mx-auto h-full flex flex-col gap-4">
+        <Card isBlurred className="p-5 bg-transparent border border-default-200">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h1 className="text-2xl md:text-3xl font-bold">{eventDraft.name || 'Untitled Lite Event'}</h1>
+              <p className="text-surface-light mt-1">
+                Date: {eventDraft.date} · Event ID: {eventDraft.id}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="bordered" onPress={() => router.push(`/lite/create?eventId=${eventDraft.id}`)}>
+                Edit Setup
+              </Button>
+              <Button className="bg-accent hover:bg-accent/90 text-white" onPress={() => router.push('/lite')}>
+                Back to Lite Home
+              </Button>
+            </div>
+          </div>
+        </Card>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1 min-h-0">
+          <Card isBlurred className="p-4 bg-transparent border border-default-200 min-h-0">
+            <h2 className="text-lg font-semibold mb-3">Staffing</h2>
+            <ScrollShadow hideScrollBar className="pr-2 h-[40dvh] md:h-[52dvh]">
+              <div className="space-y-3">
+                <div>
+                  <p className="text-sm text-surface-light mb-2">Teams ({eventDraft.staff.length})</p>
+                  {eventDraft.staff.length === 0 ? (
+                    <p className="text-sm text-surface-light/70">No teams added.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {eventDraft.staff.map((team, index) => (
+                        <div key={`${team.team}_${index}`} className="rounded-xl bg-surface-deep px-3 py-2">
+                          <p className="font-medium">{team.team}</p>
+                          <p className="text-xs text-surface-light">{team.members.join(', ')}</p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <p className="text-sm text-surface-light mb-2">Supervisors ({eventDraft.supervisor.length})</p>
+                  {eventDraft.supervisor.length === 0 ? (
+                    <p className="text-sm text-surface-light/70">No supervisors added.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {eventDraft.supervisor.map((supervisor, index) => (
+                        <div key={`${supervisor.team}_${index}`} className="rounded-xl bg-surface-deep px-3 py-2">
+                          <p className="font-medium">{supervisor.team}</p>
+                          <p className="text-xs text-surface-light">{supervisor.member}</p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </ScrollShadow>
+          </Card>
+
+          <Card isBlurred className="p-4 bg-transparent border border-default-200 min-h-0">
+            <h2 className="text-lg font-semibold mb-3">Posts, Schedule, Equipment</h2>
+            <ScrollShadow hideScrollBar className="pr-2 h-[40dvh] md:h-[52dvh]">
+              <div className="space-y-4">
+                <div>
+                  <p className="text-sm text-surface-light mb-2">Selected Posts ({eventPosts.length})</p>
+                  {eventPosts.length === 0 ? (
+                    <p className="text-sm text-surface-light/70">No posts selected.</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {eventPosts.map((post) => (
+                        <Chip key={post} variant="flat" style={{ backgroundColor: '#3eb1fd33', color: '#3eb1fd' }}>
+                          {post}
+                        </Chip>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <p className="text-sm text-surface-light mb-2">Posting Schedule ({eventDraft.postingTimes.length})</p>
+                  {eventDraft.postingTimes.length === 0 ? (
+                    <p className="text-sm text-surface-light/70">No schedule times configured.</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {eventDraft.postingTimes.map((time) => (
+                        <Chip key={time} variant="flat" style={{ backgroundColor: '#22c55e33', color: '#22c55e' }}>
+                          {time}
+                        </Chip>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <p className="text-sm text-surface-light mb-2">Event Equipment ({eventDraft.eventEquipment.length})</p>
+                  {eventDraft.eventEquipment.length === 0 ? (
+                    <p className="text-sm text-surface-light/70">No equipment selected.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {eventDraft.eventEquipment.map((equipment) => (
+                        <div key={equipment.id} className="rounded-xl bg-surface-deep px-3 py-2 text-sm">
+                          <span>{equipment.name}</span>
+                          {equipment.defaultLocation && (
+                            <span className="text-surface-light ml-2">· {equipment.defaultLocation}</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </ScrollShadow>
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/lite/events/[localEventId]/dispatch/page.tsx
+++ b/src/app/lite/events/[localEventId]/dispatch/page.tsx
@@ -13,11 +13,5 @@ export default function LiteDispatchPage() {
     [localEventId]
   );
 
-  return (
-    <SharedDispatchPage
-      params={sharedParams}
-      liteEventId={localEventId}
-      forceLiteMode={true}
-    />
-  );
+  return <SharedDispatchPage params={sharedParams} />;
 }

--- a/src/app/lite/layout.tsx
+++ b/src/app/lite/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { LiteProvider } from '@/lib/LiteContext';
+import LiteNavbar from '@/components/layout/litenavbar';
 
 /**
  * Lite Layout
@@ -28,7 +29,8 @@ export const metadata: Metadata = {
 export default function LiteLayout({ children }: { children: React.ReactNode }) {
   return (
     <LiteProvider isLiteMode={true}>
-      <div>{children}</div>
+      <LiteNavbar />
+      <div className="h-[calc(100dvh-4rem)]">{children}</div>
     </LiteProvider>
   );
 }

--- a/src/app/lite/page.tsx
+++ b/src/app/lite/page.tsx
@@ -58,7 +58,7 @@ export default function LiteLandingPage() {
   };
 
   return (
-    <main className="h-[100dvh] w-full max-w-full overflow-hidden relative flex flex-col text-surface-light bg-surface-deepest">
+    <main className="h-full w-full max-w-full overflow-hidden relative flex flex-col text-surface-light bg-surface-deepest">
       {/* Aurora background */}
       <AuroraBackground className="absolute inset-0 h-full w-full" showRadialGradient={true} />
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,13 +3,13 @@
 import React, { useEffect, useState } from 'react';
 import { FirebaseError } from 'firebase/app';
 import { useAuth } from '@/hooks/useauth';
-import { Avatar, Button, Card, CardBody, Input, Select, SelectItem, Tabs, Tab } from '@heroui/react';
+import { Avatar, Button, Card, CardBody, Input, Tabs, Tab } from '@heroui/react';
 import { auth, db } from '@/app/firebase';
 import { updatePassword, reauthenticateWithCredential, EmailAuthProvider, signOut, deleteUser } from 'firebase/auth';
 import { doc, setDoc, collection, query, where, getDocs, getDoc, deleteDoc } from 'firebase/firestore';
 import { DiagonalStreaksFixed } from '@/components/ui/diagonal-streaks-fixed';
 import LoadingScreen from '@/components/ui/loading-screen';
-import { User, Shield, Database, Settings, HelpCircle, LogOut, Trash2, Download, Eye, EyeOff } from 'lucide-react';
+import { User, Shield, Database, Settings, LogOut, Trash2, Download, Eye, EyeOff } from 'lucide-react';
 
 export default function ProfilePage() {
   const { user, ready } = useAuth();

--- a/src/components/devServiceWorkerCleanup.tsx
+++ b/src/components/devServiceWorkerCleanup.tsx
@@ -11,7 +11,7 @@ export default function DevServiceWorkerCleanup() {
       regs.forEach((r) => {
         try {
           r.unregister();
-        } catch (e) {
+        } catch {
           // ignore
         }
       });

--- a/src/components/dispatch/calltracking.tsx
+++ b/src/components/dispatch/calltracking.tsx
@@ -9,8 +9,7 @@ import {
   DropdownTrigger, 
   DropdownMenu, 
   DropdownItem,
-  Textarea,
-  ScrollShadow
+  Textarea
 } from '@heroui/react';
 import { Plus, MoreVertical } from "lucide-react";
 import type { Event, Call, EquipmentStatus, Supervisor, Staff, Equipment } from '@/app/types';
@@ -254,7 +253,7 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                 }));
                                 try {
                                   await handleCellBlur(call.id, 'chiefComplaint');
-                                } catch (err) {
+                                } catch {
                                   // ignore - pending will be cleared by effect if updated
                                 }
                               }}
@@ -301,7 +300,7 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                 }));
                                 try {
                                   await handleAgeSexBlur(call.id);
-                                } catch (err) {}
+                                } catch {}
                               }}
                               onFocus={(e) => {
                                 // Clear [Edit] placeholder on focus

--- a/src/components/dispatch/calltrackingcard.tsx
+++ b/src/components/dispatch/calltrackingcard.tsx
@@ -135,7 +135,7 @@ export default function CallTrackingCard({
   }, [call.log]);
 
   const timer = useMMSS(callTimestamp);
-  const bg = callBg(call, event);
+  const bg = getCallRowClass(call) || callBg(call, event);
 
   // Get available teams for dropdown (including On Break and In Clinic)
   const availableStaff = useMemo(() => {

--- a/src/components/dispatch/clinictracking.tsx
+++ b/src/components/dispatch/clinictracking.tsx
@@ -8,7 +8,6 @@ import {
   DropdownTrigger, 
   DropdownMenu, 
   DropdownItem,
-  ScrollShadow,
   Textarea
 } from '@heroui/react';
 import { Plus, MoreVertical } from 'lucide-react';

--- a/src/components/dispatch/clinictrackingcard.tsx
+++ b/src/components/dispatch/clinictrackingcard.tsx
@@ -37,7 +37,7 @@ function useMMSS(since?: number) {
   return `${mm}:${ss}`;
 }
 
-function callBg(call: Call) {
+function callBg() {
   // Clinic calls always use default background
   return 'bg-surface-deep';
 }
@@ -108,7 +108,7 @@ export default function ClinicTrackingCard({
   }, [call.log]);
 
   const timer = useMMSS(callTimestamp);
-  const bg = callBg(call);
+  const bg = getCallRowClass(call) || callBg();
 
   // Get primary team (first assigned team or first detached team)
   const primaryTeam = useMemo(() => {

--- a/src/components/dispatch/equipmentcard.tsx
+++ b/src/components/dispatch/equipmentcard.tsx
@@ -2,9 +2,9 @@
 
 'use client';
 
-import React, { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import {
-  Card, CardBody, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem,
+  Card, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem,
   Select, SelectItem, Autocomplete, AutocompleteItem, Textarea
 } from '@heroui/react';
 import { MoreVertical } from 'lucide-react';
@@ -60,10 +60,6 @@ export default function EquipmentCard({
   }, [equipment.currentLocation, equipment.stagingLocation, equipment.deliveryTeam]);
 
   const isOnCall = equipment.status.startsWith('Call ');
-  
-  const associatedCall = equipment.callId 
-    ? event.calls?.find(c => c.id === equipment.callId)
-    : null;
 
   const statusOptions = ['Available', 'In Use', 'In Clinic'];
 
@@ -74,22 +70,7 @@ export default function EquipmentCard({
     return 'Available';
   })();
 
-  // Location options
-  const locationOptions: string[] = React.useMemo(() => {
-    const base: string[] = ['Clinic'];
-    const posts = (event.venue?.posts || []).map(p => (typeof p === 'string' ? p : p.name));
-    return Array.from(new Set([...base, ...posts, equipment.stagingLocation].filter(Boolean)));
-  }, [event.venue?.posts, equipment.stagingLocation]);
-
   const bg = equipmentBg(equipment.status);
-
-  const displayLocation = (() => {
-    if (equipment.deliveryTeam) return equipment.deliveryTeam;
-    if (isOnCall && associatedCall?.assignedTeam && associatedCall.assignedTeam.length) return associatedCall.assignedTeam[0];
-    if (equipment.currentLocation && event?.staff?.some(s => s.team === equipment.currentLocation)) return equipment.currentLocation;
-    if (equipment.needsRefresh) return 'In Clinic';
-    return equipment.currentLocation || equipment.stagingLocation || 'Not Set';
-  })();
 
   return (
     <Card

--- a/src/components/dispatch/teamcard-condensed.tsx
+++ b/src/components/dispatch/teamcard-condensed.tsx
@@ -35,23 +35,6 @@ function useMMSS(since?: number) {
   return `${mm}:${ss}`;
 }
 
-function getLeadNameCert(staff: Staff) {
-  const isSupervisor =
-    Array.isArray(staff.members) &&
-    staff.members.length === 1 &&
-    typeof staff.members[0] === 'string' &&
-    !staff.members[0].includes('(Lead)');
-
-  if (isSupervisor) {
-    const m = staff.members?.[0] ?? '';
-    const rx = m.match(/^(.+?)\s\[(.+?)\]/);
-    return { name: rx?.[1] ?? m, cert: rx?.[2] ?? '' };
-  }
-  const lead = (staff.members || []).find(m => typeof m === 'string' && m.includes('(Lead)')) || '';
-  const rx = lead.match(/^(.+?)\s\[(.+?)\]/);
-  return { name: rx?.[1] ?? 'No Lead', cert: rx?.[2] ?? '' };
-}
-
 function teamBg(status: string, event: Event, team: string) {
   // Check if team is assisting with equipment (orange)
   const onEqRun =
@@ -110,8 +93,7 @@ export default function TeamCardCondensed({
   useEffect(() => {
     setLocationInput(staff.location || '');
   }, [staff.location]);
-  
-  const {name, cert} = useMemo(() => getLeadNameCert(staff), [staff]);
+
   const timer = useMMSS(sinceMs);
 
   // Status options

--- a/src/components/layout/appnavbar.tsx
+++ b/src/components/layout/appnavbar.tsx
@@ -25,7 +25,7 @@ import {
   Avatar,
 } from "@heroui/react";
 
-import { Menu, UserRound, Cog, LogOut } from "lucide-react";
+import { Menu, UserRound, LogOut } from "lucide-react";
 
 const LoginModalLazy = dynamic(() => import("@/components/modals/auth/loginmodal"), { ssr: false });
 

--- a/src/components/layout/litenavbar.tsx
+++ b/src/components/layout/litenavbar.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { signOut } from 'firebase/auth';
+import { auth } from '@/app/firebase';
+import { useAuth } from '@/hooks/useauth';
+import {
+  Avatar,
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownTrigger,
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarItem,
+  NavbarMenu,
+  NavbarMenuItem,
+  NavbarMenuToggle,
+} from '@heroui/react';
+import { LogOut, Menu, UserRound } from 'lucide-react';
+
+const LoginModalLazy = dynamic(() => import('@/components/modals/auth/loginmodal'), {
+  ssr: false,
+});
+
+function initialsFromUser(u?: { displayName?: string | null; email?: string | null }) {
+  const fromName =
+    u?.displayName
+      ?.trim()
+      .split(/\s+/)
+      .map((segment) => segment[0]?.toUpperCase())
+      .join('') ?? '';
+  if (fromName) return fromName.slice(0, 2);
+  return (u?.email?.[0] ?? 'U').toUpperCase();
+}
+
+const liteNavItems = [
+  { label: 'Lite Home', href: '/lite' },
+  { label: 'Create', href: '/lite/create' },
+  { label: 'Cloud Home', href: '/' },
+];
+
+export default function LiteNavbar() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { user, ready } = useAuth();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [loginOpen, setLoginOpen] = useState(false);
+  const [loginMode, setLoginMode] = useState<'login' | 'signup'>('login');
+
+  const isActive = (href: string) => pathname === href;
+  const initials = initialsFromUser(user ?? undefined);
+
+  const onLogout = async () => {
+    await signOut(auth);
+    document.cookie = 'ccad_auth=0; Max-Age=0; Path=/; SameSite=Lax';
+    router.refresh();
+    router.push('/');
+  };
+
+  return (
+    <>
+      <Navbar
+        isBlurred
+        position="sticky"
+        maxWidth="full"
+        isMenuOpen={isMenuOpen}
+        onMenuOpenChange={setIsMenuOpen}
+        classNames={{
+          base: 'sticky top-0 z-[300] bg-surface-deepest/70 backdrop-blur-md',
+          wrapper:
+            'h-16 md:h-16 px-4 sm:px-6 md:px-6 lg:px-6 xl:px-6 2xl:px-6 flex items-center',
+          item: 'text-[18px] leading-6',
+          content: 'items-center',
+          toggle: 'lg:hidden',
+          menu:
+            'fixed inset-x-0 top-16 z-[350] bg-surface-deep/95 backdrop-blur supports-[backdrop-filter]:bg-opacity-90 ' +
+            'h-[calc(100dvh-4rem)] overflow-y-auto pt-2 pb-6 border-t border-base-200',
+          menuItem: 'justify-center text-surface-light',
+        }}
+      >
+        <div className="relative flex items-center justify-between w-full max-w-[1200px] mx-auto">
+          <NavbarContent justify="start" className="min-w-0">
+            <NavbarBrand>
+              <button onClick={() => router.push('/lite')} className="flex items-center">
+                <Image
+                  src="/logo.svg"
+                  alt="Logo"
+                  width={140}
+                  height={30}
+                  priority
+                  sizes="(max-width: 600px) 7rem, (max-width: 800px) 8rem, 110px"
+                  className="cursor-pointer w-24 h-auto"
+                />
+              </button>
+            </NavbarBrand>
+          </NavbarContent>
+
+          <NavbarContent
+            className="hidden lg:flex gap-8 absolute left-1/2 -translate-x-1/2"
+            justify="center"
+          >
+            {liteNavItems.map(({ label, href }) => (
+              <NavbarItem key={href} isActive={isActive(href)}>
+                <Link
+                  href={href}
+                  className={`text-lg font-medium transition ${
+                    isActive(href) ? 'text-surface-light' : 'text-surface-faint hover:text-accent'
+                  }`}
+                >
+                  {label}
+                </Link>
+              </NavbarItem>
+            ))}
+          </NavbarContent>
+
+          <NavbarContent justify="end" className="gap-2 sm:gap-3 md:gap-4">
+            <div className="lg:hidden">
+              <NavbarMenuToggle
+                aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+                className="text-white"
+                icon={(open) => (
+                  <Menu className={`size-6 transition ${open ? 'rotate-90' : ''}`} color="white" />
+                )}
+              />
+            </div>
+
+            {!ready ? (
+              <NavbarItem>
+                <div className="w-10 h-10" />
+              </NavbarItem>
+            ) : !user ? (
+              <NavbarItem>
+                <Button
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    setLoginOpen(true);
+                  }}
+                >
+                  Log in
+                </Button>
+              </NavbarItem>
+            ) : (
+              <NavbarItem className="hidden lg:flex">
+                <Dropdown placement="bottom-end">
+                  <DropdownTrigger>
+                    <button
+                      aria-label="Open profile menu"
+                      className="relative p-0.5 rounded-full bg-gradient-to-br from-accent/70 to-[rgba(240,28,28,0.4)] cursor-pointer"
+                    >
+                      <Avatar
+                        isBordered
+                        showFallback
+                        name={initials}
+                        classNames={{
+                          base: 'bg-surface-base',
+                          name: 'text-surface-light text-xs',
+                        }}
+                        className="w-8 h-8"
+                      />
+                    </button>
+                  </DropdownTrigger>
+
+                  <DropdownMenu
+                    aria-label="Profile menu"
+                    className="min-w-40 flex flex-col space-y-1 origin-top-right transform-gpu transition-all duration-150"
+                  >
+                    <DropdownItem
+                      key="profile"
+                      startContent={<UserRound className="size-4" />}
+                      className="transition-colors"
+                      onPress={() => router.push('/profile')}
+                    >
+                      Profile
+                    </DropdownItem>
+                    <DropdownItem
+                      key="logout"
+                      className="text-status-red"
+                      startContent={<LogOut className="size-4" />}
+                      onPress={onLogout}
+                    >
+                      Logout
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+              </NavbarItem>
+            )}
+          </NavbarContent>
+        </div>
+
+        <NavbarMenu className="bg-surface-deep border-t border-surface-liner pt-6">
+          {liteNavItems.map(({ label, href }) => (
+            <NavbarMenuItem key={href}>
+              <Link
+                href={href}
+                onClick={() => setIsMenuOpen(false)}
+                className={`w-full text-lg font-medium transition ${
+                  isActive(href) ? 'text-surface-light' : 'text-surface-faint hover:text-accent'
+                }`}
+              >
+                {label}
+              </Link>
+            </NavbarMenuItem>
+          ))}
+
+          <div className="my-2 border-t border-surface-liner" />
+
+          {!user ? (
+            <>
+              <NavbarMenuItem className="mt-1">
+                <button
+                  className="block w-full text-left text-[18px] px-2 py-2 rounded-md"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    setLoginMode('login');
+                    setLoginOpen(true);
+                  }}
+                >
+                  Log in
+                </button>
+              </NavbarMenuItem>
+              <NavbarMenuItem className="mt-1">
+                <button
+                  className="block w-full text-left text-[18px] px-2 py-2 rounded-md"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    setLoginMode('signup');
+                    setLoginOpen(true);
+                  }}
+                >
+                  Sign up
+                </button>
+              </NavbarMenuItem>
+            </>
+          ) : (
+            <>
+              <NavbarMenuItem>
+                <Link
+                  href="/profile"
+                  className="w-full text-lg font-medium transition text-surface-faint hover:text-accent"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  Profile
+                </Link>
+              </NavbarMenuItem>
+              <NavbarMenuItem>
+                <button
+                  className="w-full text-left text-lg font-medium transition text-status-red hover:opacity-80"
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    onLogout();
+                  }}
+                >
+                  Logout
+                </button>
+              </NavbarMenuItem>
+            </>
+          )}
+        </NavbarMenu>
+      </Navbar>
+
+      {loginOpen && (
+        <LoginModalLazy
+          open={loginOpen}
+          mode={loginMode}
+          onClose={() => setLoginOpen(false)}
+          setMode={setLoginMode}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/layout/litenavbar.tsx
+++ b/src/components/layout/litenavbar.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { signOut } from 'firebase/auth';
 import { auth } from '@/app/firebase';
 import { useAuth } from '@/hooks/useauth';
@@ -22,6 +22,7 @@ import {
   NavbarMenu,
   NavbarMenuItem,
   NavbarMenuToggle,
+  Chip,
 } from '@heroui/react';
 import { LogOut, Menu, UserRound } from 'lucide-react';
 
@@ -40,6 +41,19 @@ function initialsFromUser(u?: { displayName?: string | null; email?: string | nu
   return (u?.email?.[0] ?? 'U').toUpperCase();
 }
 
+function LiveClock() {
+  const [now, setNow] = useState<Date>(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <span suppressHydrationWarning={true} className="tabular-nums text-surface-light text-lg font-semibold font-arial">
+      {now.toLocaleTimeString([], { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+    </span>
+  );
+}
+
 const liteNavItems = [
   { label: 'Lite Home', href: '/lite' },
   { label: 'Create', href: '/lite/create' },
@@ -53,9 +67,22 @@ export default function LiteNavbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
   const [loginMode, setLoginMode] = useState<'login' | 'signup'>('login');
+  const isDispatch = !!(pathname && /^\/lite\/events\/[^/]+\/dispatch(?:$|\/|\?)/.test(pathname));
 
   const isActive = (href: string) => pathname === href;
   const initials = initialsFromUser(user ?? undefined);
+
+  const openPostingSchedule = () => {
+    window.dispatchEvent(new CustomEvent('open-posting-schedule'));
+  };
+
+  const triggerClearEvent = () => {
+    window.dispatchEvent(new CustomEvent('open-lite-clear-event'));
+  };
+
+  const triggerExportSummary = () => {
+    window.dispatchEvent(new CustomEvent('open-lite-export-summary'));
+  };
 
   const onLogout = async () => {
     await signOut(auth);
@@ -85,10 +112,11 @@ export default function LiteNavbar() {
           menuItem: 'justify-center text-surface-light',
         }}
       >
-        <div className="relative flex items-center justify-between w-full max-w-[1200px] mx-auto">
+        <div className={`flex items-center justify-between w-full ${!isDispatch ? 'max-w-[1200px] mx-auto' : ''}`}>
+          {/* LEFT: brand */}
           <NavbarContent justify="start" className="min-w-0">
             <NavbarBrand>
-              <button onClick={() => router.push('/lite')} className="flex items-center">
+              <button onClick={() => router.push("/")} className="flex items-center">
                 <Image
                   src="/logo.svg"
                   alt="Logo"
@@ -99,25 +127,73 @@ export default function LiteNavbar() {
                   className="cursor-pointer w-24 h-auto"
                 />
               </button>
+
+              {isDispatch && (
+                <div className="ml-4 sm:ml-6 md:ml-8">
+                  <LiveClock />
+                  <Chip size="lg" color="success" variant="flat" className="ml-4">
+                    Lite Mode
+                  </Chip>
+                </div>
+                
+              )}
             </NavbarBrand>
           </NavbarContent>
 
           <NavbarContent
-            className="hidden lg:flex gap-8 absolute left-1/2 -translate-x-1/2"
+            className={`hidden lg:flex gap-8 ${!isDispatch ? 'max-w-[500px]' : ''}`}
             justify="center"
           >
-            {liteNavItems.map(({ label, href }) => (
-              <NavbarItem key={href} isActive={isActive(href)}>
-                <Link
-                  href={href}
-                  className={`text-lg font-medium transition ${
-                    isActive(href) ? 'text-surface-light' : 'text-surface-faint hover:text-accent'
-                  }`}
-                >
-                  {label}
-                </Link>
-              </NavbarItem>
-            ))}
+            {isDispatch ? (
+              <>
+                <NavbarItem>
+                  <button
+                    onClick={openPostingSchedule}
+                    className="text-lg font-medium transition text-surface-light hover:text-accent"
+                  >
+                    Posting Schedule
+                  </button>
+                </NavbarItem>
+
+                <NavbarItem>
+                  <Dropdown placement="bottom-start">
+                    <DropdownTrigger>
+                      <button
+                        type="button"
+                        className="text-lg font-medium transition text-surface-light hover:text-accent"
+                      >
+                        End Event
+                      </button>
+                    </DropdownTrigger>
+                    <DropdownMenu aria-label="Lite end event actions">
+                      <DropdownItem
+                        key="clear-event"
+                        className="text-status-red"
+                        onPress={triggerClearEvent}
+                      >
+                        Clear Event
+                      </DropdownItem>
+                      <DropdownItem key="export-summary" onPress={triggerExportSummary}>
+                        Export Summary
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </Dropdown>
+                </NavbarItem>
+              </>
+            ) : (
+              liteNavItems.map(({ label, href }) => (
+                <NavbarItem key={href} isActive={isActive(href)}>
+                  <Link
+                    href={href}
+                    className={`text-lg font-medium transition ${
+                      isActive(href) ? 'text-surface-light' : 'text-surface-faint hover:text-accent'
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                </NavbarItem>
+              ))
+            )}
           </NavbarContent>
 
           <NavbarContent justify="end" className="gap-2 sm:gap-3 md:gap-4">
@@ -195,19 +271,57 @@ export default function LiteNavbar() {
         </div>
 
         <NavbarMenu className="bg-surface-deep border-t border-surface-liner pt-6">
-          {liteNavItems.map(({ label, href }) => (
-            <NavbarMenuItem key={href}>
-              <Link
-                href={href}
-                onClick={() => setIsMenuOpen(false)}
-                className={`w-full text-lg font-medium transition ${
-                  isActive(href) ? 'text-surface-light' : 'text-surface-faint hover:text-accent'
-                }`}
-              >
-                {label}
-              </Link>
-            </NavbarMenuItem>
-          ))}
+          {isDispatch ? (
+            <>
+              <NavbarMenuItem>
+                <button
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    openPostingSchedule();
+                  }}
+                  className="block w-full text-left text-[18px] px-2 py-2"
+                >
+                  Posting Schedule
+                </button>
+              </NavbarMenuItem>
+              <NavbarMenuItem>
+                <button
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    triggerClearEvent();
+                  }}
+                  className="block w-full text-left text-[18px] px-2 py-2 text-status-red"
+                >
+                  Clear Event
+                </button>
+              </NavbarMenuItem>
+              <NavbarMenuItem>
+                <button
+                  onClick={() => {
+                    setIsMenuOpen(false);
+                    triggerExportSummary();
+                  }}
+                  className="block w-full text-left text-[18px] px-2 py-2"
+                >
+                  Export Summary
+                </button>
+              </NavbarMenuItem>
+            </>
+          ) : (
+            liteNavItems.map(({ label, href }) => (
+              <NavbarMenuItem key={href}>
+                <Link
+                  href={href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className={`w-full text-lg font-medium transition ${
+                    isActive(href) ? 'text-surface-light' : 'text-surface-faint hover:text-accent'
+                  }`}
+                >
+                  {label}
+                </Link>
+              </NavbarMenuItem>
+            ))
+          )}
 
           <div className="my-2 border-t border-surface-liner" />
 

--- a/src/components/modals/event/venuemapmodal.tsx
+++ b/src/components/modals/event/venuemapmodal.tsx
@@ -2,8 +2,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import Image from 'next/image';
-import { Modal, ModalContent, ModalBody, Button, Card, Tooltip } from '@heroui/react';
-import { ZoomIn, ZoomOut, RotateCcw, MapPin, Cross, ShieldPlus, Briefcase, HousePlus } from 'lucide-react';
+import { Modal, ModalContent, ModalBody, Button, Card } from '@heroui/react';
+import { ZoomIn, ZoomOut, RotateCcw, MapPin, ShieldPlus, Briefcase, HousePlus } from 'lucide-react';
 import { Post, Staff, Equipment, Layer } from '@/app/types';
 
 function StatusTimer({ since }: { since: number }) {
@@ -112,28 +112,6 @@ function PostMarker({ post, rect }: PostMarkerProps) {
   );
 }
 
-function getEquipmentMarkerColors(equipment: Equipment) {
-  let color = '#8B5CF6'; // Purple for default
-  const outline = '2px solid white';
-
-  switch (equipment.status) {
-    case 'Available':
-      color = '#10B981'; // Green
-      break;
-    case 'En Route to Call':
-      color = '#F59E0B'; // Amber
-      break;
-    case 'Transporting Patient':
-      color = '#EF4444'; // Red
-      break;
-    case 'Out of Service':
-      color = '#6B7280'; // Gray
-      break;
-  }
-
-  return { color, outline };
-}
-
 function getEquipmentIcon(equipment: Equipment) {
   const name = equipment.name.toLowerCase();
   
@@ -155,22 +133,24 @@ function getEquipmentIcon(equipment: Equipment) {
 function EquipmentIcon({ type, className }: { type: string; className?: string }) {
   if (type === 'wheelchair') {
     return (
-      <img 
-        src="/map/wheelchair.svg" 
-        alt="Wheelchair" 
+      <Image
+        src="/map/wheelchair.svg"
+        alt="Wheelchair"
+        width={24}
+        height={24}
         className={className}
-        style={{ width: '100%', height: '100%' }}
         draggable={false}
       />
     );
   }
   if (type === 'stretcher') {
     return (
-      <img 
-        src="/map/gurney.svg" 
-        alt="Gurney" 
+      <Image
+        src="/map/gurney.svg"
+        alt="Gurney"
+        width={24}
+        height={24}
         className={className}
-        style={{ width: '100%', height: '100%' }}
         draggable={false}
       />
     );

--- a/src/components/modals/venue/locationedit.tsx
+++ b/src/components/modals/venue/locationedit.tsx
@@ -80,7 +80,7 @@ export default function LocationEditModal({
       }}
     >
       <ModalContent>
-        {(close) => (
+        {() => (
           <>
             <ModalHeader className="text-2xl font-bold text-surface">
               Edit Location

--- a/src/components/modals/venue/newlayer.tsx
+++ b/src/components/modals/venue/newlayer.tsx
@@ -61,7 +61,7 @@ export default function NewLayerModal({ isOpen, onClose, onSubmit }: Props) {
       }}
     >
       <ModalContent>
-        {(close) => (
+        {() => (
           <>
             <ModalHeader className="text-2xl font-bold text-surface">
               Add New Layer

--- a/src/components/ui/codesnippet.tsx
+++ b/src/components/ui/codesnippet.tsx
@@ -12,7 +12,7 @@ export default function CodeSnippet({ code, label }: { code: string; label?: str
       await navigator.clipboard.writeText(code);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (e) {
+    } catch {
       // no-op
     }
   }

--- a/src/lib/liteEventStore.ts
+++ b/src/lib/liteEventStore.ts
@@ -4,6 +4,7 @@ import type {
   Call,
   Equipment,
   EventEquipment,
+  PostAssignment,
   Post,
   Staff,
   Supervisor,
@@ -41,6 +42,10 @@ export interface LiteEventDraft {
   staff: Staff[];
   supervisor: Supervisor[];
   eventPosts: Post[];
+  postAssignments?: PostAssignment;
+  pendingAssignments?: {
+    [team: string]: { post: string; time: string };
+  };
   eventEquipment: EventEquipment[];
   calls: Call[];
   status: 'draft' | 'active';
@@ -155,6 +160,8 @@ export function createDefaultLiteEventDraft(eventId: string, eventName = ''): Li
     staff: [],
     supervisor: [],
     eventPosts: [],
+    postAssignments: {},
+    pendingAssignments: {},
     eventEquipment: [],
     calls: [],
     status: 'draft',
@@ -228,4 +235,125 @@ export async function deleteLiteEvent(eventId: string): Promise<void> {
   }
 
   fallbackDeleteFromLocalStorage(eventId);
+}
+
+/**
+ * Dispatch update helpers — all mutations persist immediately to local storage
+ */
+
+export async function updateLiteEventStatus(eventId: string, status: 'draft' | 'active'): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = { ...event, status };
+  await saveLiteEvent(updated);
+  return updated;
+}
+
+export async function addLiteCall(eventId: string, call: Call): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = {
+    ...event,
+    calls: [...event.calls, call],
+  };
+  await saveLiteEvent(updated);
+  return updated;
+}
+
+export async function updateLiteCall(eventId: string, callId: string, updates: Partial<Call>): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = {
+    ...event,
+    calls: event.calls.map((c) => (c.id === callId ? { ...c, ...updates } : c)),
+  };
+  await saveLiteEvent(updated);
+  return updated;
+}
+
+export async function deleteLiteCall(eventId: string, callId: string): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = {
+    ...event,
+    calls: event.calls.filter((c) => c.id !== callId),
+  };
+  await saveLiteEvent(updated);
+  return updated;
+}
+
+export async function updateLiteTeamStatus(
+  eventId: string,
+  teamName: string,
+  status: string,
+  location?: string
+): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = {
+    ...event,
+    staff: event.staff.map((team) => {
+      if (team.team === teamName) {
+        return { ...team, status, location: location ?? team.location };
+      }
+      return team;
+    }),
+  };
+  await saveLiteEvent(updated);
+  return updated;
+}
+
+export async function updateLiteSupervisorStatus(
+  eventId: string,
+  supervisorTeam: string,
+  status: string,
+  location?: string
+): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = {
+    ...event,
+    supervisor: event.supervisor.map((sup) => {
+      if (sup.team === supervisorTeam) {
+        return { ...sup, status, location: location ?? sup.location };
+      }
+      return sup;
+    }),
+  };
+  await saveLiteEvent(updated);
+  return updated;
+}
+
+export async function updateLiteEquipmentStatus(
+  eventId: string,
+  equipmentId: string,
+  status: string,
+  assignedTeam?: string | null,
+  location?: string
+): Promise<LiteEventDraft | null> {
+  const event = await getLiteEvent(eventId);
+  if (!event) return null;
+
+  const updated = {
+    ...event,
+    eventEquipment: event.eventEquipment.map((eq) => {
+      if (eq.id === equipmentId) {
+        return {
+          ...eq,
+          status,
+          assignedTeam: assignedTeam ?? eq.assignedTeam,
+          location: location ?? eq.location,
+        };
+      }
+      return eq;
+    }),
+  };
+  await saveLiteEvent(updated);
+  return updated;
 }

--- a/src/lib/liteEventStore.ts
+++ b/src/lib/liteEventStore.ts
@@ -1,0 +1,231 @@
+'use client';
+
+import type {
+  Call,
+  Equipment,
+  EventEquipment,
+  Post,
+  Staff,
+  Supervisor,
+} from '@/app/types';
+
+const DB_NAME = 'crowdcad-lite';
+const DB_VERSION = 1;
+const EVENTS_STORE = 'events';
+const LEGACY_STORAGE_PREFIX = 'lite_event_';
+
+const hasIndexedDb = () =>
+  typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+
+const hasLocalStorage = () =>
+  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export interface LiteVenueSetup {
+  name: string;
+  posts: Post[];
+  equipment: Equipment[];
+}
+
+export interface LiteEventDraft {
+  id: string;
+  mode: 'lite';
+  name: string;
+  date: string;
+  scheduleConfig: {
+    from: string;
+    to: string;
+    by: string;
+  };
+  venue: LiteVenueSetup;
+  postingTimes: string[];
+  staff: Staff[];
+  supervisor: Supervisor[];
+  eventPosts: Post[];
+  eventEquipment: EventEquipment[];
+  calls: Call[];
+  status: 'draft' | 'active';
+  createdAt: string;
+  updatedAt: string;
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+  });
+}
+
+function transactionComplete(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+  });
+}
+
+function openLiteDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (!hasIndexedDb()) {
+      reject(new Error('IndexedDB unavailable'));
+      return;
+    }
+
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(EVENTS_STORE)) {
+        db.createObjectStore(EVENTS_STORE, { keyPath: 'id' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('Failed to open IndexedDB'));
+  });
+}
+
+function fallbackSaveToLocalStorage(event: LiteEventDraft): void {
+  if (!hasLocalStorage()) return;
+  window.localStorage.setItem(`${LEGACY_STORAGE_PREFIX}${event.id}`, JSON.stringify(event));
+}
+
+function fallbackReadFromLocalStorage(id: string): LiteEventDraft | null {
+  if (!hasLocalStorage()) return null;
+  const raw = window.localStorage.getItem(`${LEGACY_STORAGE_PREFIX}${id}`);
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as LiteEventDraft;
+  } catch {
+    return null;
+  }
+}
+
+function fallbackDeleteFromLocalStorage(id: string): void {
+  if (!hasLocalStorage()) return;
+  window.localStorage.removeItem(`${LEGACY_STORAGE_PREFIX}${id}`);
+}
+
+function fallbackListFromLocalStorage(): LiteEventDraft[] {
+  if (!hasLocalStorage()) return [];
+
+  const events: LiteEventDraft[] = [];
+  for (let index = 0; index < window.localStorage.length; index += 1) {
+    const key = window.localStorage.key(index);
+    if (!key || !key.startsWith(LEGACY_STORAGE_PREFIX)) continue;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) continue;
+      events.push(JSON.parse(raw) as LiteEventDraft);
+    } catch {
+      continue;
+    }
+  }
+
+  return events.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export function generateLiteEventId(): string {
+  const random =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+      : Math.random().toString(36).slice(2, 14);
+
+  return `local_${Date.now()}_${random}`;
+}
+
+export function createDefaultLiteEventDraft(eventId: string, eventName = ''): LiteEventDraft {
+  const now = new Date().toISOString();
+  return {
+    id: eventId,
+    mode: 'lite',
+    name: eventName,
+    date: now.split('T')[0],
+    scheduleConfig: {
+      from: '16:00',
+      to: '23:59',
+      by: '75',
+    },
+    venue: {
+      name: 'Lite Event',
+      posts: [],
+      equipment: [],
+    },
+    postingTimes: [],
+    staff: [],
+    supervisor: [],
+    eventPosts: [],
+    eventEquipment: [],
+    calls: [],
+    status: 'draft',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function saveLiteEvent(event: LiteEventDraft): Promise<void> {
+  const withUpdatedAt: LiteEventDraft = {
+    ...event,
+    updatedAt: new Date().toISOString(),
+  };
+
+  try {
+    const db = await openLiteDb();
+    const transaction = db.transaction(EVENTS_STORE, 'readwrite');
+    const store = transaction.objectStore(EVENTS_STORE);
+    store.put(withUpdatedAt);
+    await transactionComplete(transaction);
+    db.close();
+    fallbackSaveToLocalStorage(withUpdatedAt);
+  } catch {
+    fallbackSaveToLocalStorage(withUpdatedAt);
+  }
+}
+
+export async function getLiteEvent(eventId: string): Promise<LiteEventDraft | null> {
+  try {
+    const db = await openLiteDb();
+    const transaction = db.transaction(EVENTS_STORE, 'readonly');
+    const store = transaction.objectStore(EVENTS_STORE);
+    const result = await requestToPromise<LiteEventDraft | undefined>(store.get(eventId));
+    db.close();
+    if (result) return result;
+  } catch {
+    // no-op, fallback below
+  }
+
+  return fallbackReadFromLocalStorage(eventId);
+}
+
+export async function listLiteEvents(): Promise<LiteEventDraft[]> {
+  try {
+    const db = await openLiteDb();
+    const transaction = db.transaction(EVENTS_STORE, 'readonly');
+    const store = transaction.objectStore(EVENTS_STORE);
+    const result = await requestToPromise<LiteEventDraft[]>(store.getAll());
+    db.close();
+
+    if (Array.isArray(result) && result.length > 0) {
+      return result.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    }
+  } catch {
+    // no-op, fallback below
+  }
+
+  return fallbackListFromLocalStorage();
+}
+
+export async function deleteLiteEvent(eventId: string): Promise<void> {
+  try {
+    const db = await openLiteDb();
+    const transaction = db.transaction(EVENTS_STORE, 'readwrite');
+    const store = transaction.objectStore(EVENTS_STORE);
+    store.delete(eventId);
+    await transactionComplete(transaction);
+    db.close();
+  } catch {
+    // no-op, fallback below
+  }
+
+  fallbackDeleteFromLocalStorage(eventId);
+}


### PR DESCRIPTION
## Summary
This PR finalizes Lite Mode end-to-end and closes the remaining tracked sub-issues on the same branch.

## What changed

### Lite Mode parity + UX
- Aligned Lite dispatch/navbar behavior with the main app navbar:
  - centered desktop nav behavior
  - auth controls parity (logged out: login button, logged in: avatar menu)
  - dispatch-time controls and visual consistency
- Refined layout polish in Lite setup/dispatch flows:
  - consistent right-panel header spacing
  - team/supervisor cards no longer stretch unnecessarily
  - team edit flow integrated via existing modal UX
- Simplified mode messaging to a single Lite indicator chip.

### Dispatch architecture and behavior
- Consolidated Lite + Cloud dispatch behavior through shared dispatch logic and mode-aware handling.
- Kept Lite mode local-only behavior intact (no Firebase sync dependency for Lite workflows).

### Build, type, and lint hardening
- Fixed Next.js page export/type validity issues for dispatch routes.
- Removed/cleaned unused imports, variables, and stale directives that caused build blockers.
- Updated venue map icon rendering to satisfy Next.js lint requirements.
- Build now passes cleanly (`npm run build`).

### Docs and release notes
- Updated Lite mode documentation and workflow notes.
- Updated changelog `Unreleased` section with Lite completion + build fixes.

## Validation
- [x] `npm run build` passes
- [x] Manual QA for Lite setup/dispatch/nav/auth flows
- [x] Type/lint blockers from build output resolved

## Related issues
Closes #1
Closes #3
Closes #4
Closes #5