### PR TITLE
Fix team-status dropdown spurious self-close on dispatch board

### DIFF
--- a/src/components/dispatch/calltracking.tsx
+++ b/src/components/dispatch/calltracking.tsx
@@ -111,6 +111,14 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
   const [closingCallId, setClosingCallId] = React.useState<string | null>(null);
   const [openMenuToken, setOpenMenuToken] = React.useState<string | null>(null);
   const previousOpenCallIdRef = React.useRef<string | null>(null);
+  // HeroUI/react-aria's Popover can spuriously fire onOpenChange(false) a few
+  // milliseconds after opening, with no user interaction (a known upstream
+  // focus/blur-tracking race — see adobe/react-spectrum#4533). Real users
+  // never dismiss a menu that fast, so ignore closes inside this window
+  // unless they came from an actual selection (onAction).
+  const TEAM_STATUS_MENU_CLOSE_GUARD_MS = 150;
+  const teamStatusMenuOpenedAtRef = React.useRef<number>(0);
+  const teamStatusMenuSelectedRef = React.useRef<boolean>(false);
   const {
     notesTexts,
     setNotesTexts,
@@ -437,7 +445,13 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                       onOpenChange={(isOpen) => {
                                         if (isOpen) {
                                           if (isResolvedCall && !showResolvedCalls) return;
+                                          teamStatusMenuOpenedAtRef.current = Date.now();
                                           setOpenMenuToken(`team-status:${call.id}:${team}`);
+                                          return;
+                                        }
+                                        const selected = teamStatusMenuSelectedRef.current;
+                                        teamStatusMenuSelectedRef.current = false;
+                                        if (!selected && Date.now() - teamStatusMenuOpenedAtRef.current < TEAM_STATUS_MENU_CLOSE_GUARD_MS) {
                                           return;
                                         }
                                         setOpenMenuToken((current) =>
@@ -456,7 +470,10 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                       </DropdownTrigger>
                                       <DropdownMenu
                                         aria-label="Team status"
-                                        onAction={(key) => handleTeamStatusChange(call.id, team, key as string)}
+                                        onAction={(key) => {
+                                          teamStatusMenuSelectedRef.current = true;
+                                          handleTeamStatusChange(call.id, team, key as string);
+                                        }}
                                       >
                                         {statusOptions.map((status: string) => (
                                           <DropdownItem key={status}>{status}</DropdownItem>


### PR DESCRIPTION
## Summary
- Fixes #14 — the team-status Dropdown on the dispatch board (calls/clinic tracking) intermittently closed itself 15-35ms after opening, with no user interaction, before a status option could be clicked.
- Root cause is an unresolved upstream react-aria/HeroUI Popover focus/blur-tracking race (adobe/react-spectrum#4533), not a bug in this app's state management.
- Fix: ignore `onOpenChange(false)` if it fires within 150ms of opening and wasn't the result of an actual selection. Real users never dismiss a just-opened menu that fast, so this only suppresses the spurious closes.

## Investigation trail (see issue #14 for full detail)
Instrumented a local repro against the Firebase emulator and ruled out, empirically, in order:
1. The existing "auto-close resolved call" effect — never fired during the failures.
2. Duplicate desktop/mobile DOM mounts — already fixed in #13, confirmed independent of this bug (reproduced on a single desktop-only run).
3. Custom `motionProps` (framer-motion) — removed entirely, bug persisted at the same ~50-60% failure rate.
4. `shouldCloseOnBlur={false}` — no effect, bug persisted.

The close-guard fix was then verified to eliminate the failures.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (no new warnings/errors)
- [x] Firebase: 41/41 passed across 5 repeats of all previously-affected scenarios (Refusal status, Full call lifecycle, clinic outcome scenarios, event-summary status transitions) — previously failing/flaky ~50-60% of the time
- [x] PocketBase: 10/10 passed across 3 repeats of the same core scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)