### PR TITLE
Availability tracking and surge notification

### DIFF
--- a/src/app/(main)/events/[eventId]/create/page.tsx
+++ b/src/app/(main)/events/[eventId]/create/page.tsx
@@ -52,6 +52,7 @@ export default function EventCreation() {
     calls: [],
     eventPosts: [],
     eventEquipment: [],
+    surgeLimitPercent: 70,
   });
 
   const [selectedTab, setSelectedTab] = useState<'teams' | 'supervisors' | 'posts' | 'equipment'>('teams');

--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -29,6 +29,7 @@ import DebugModal from '@/components/modals/debugmodal';
 import { ShieldAlert } from 'lucide-react';
 import { Select, SelectItem, Tabs, Tab, Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Tooltip } from "@heroui/react"
 import EquipmentCard from '@/components/dispatch/equipmentcard';
+import AvailabilitySurgeStrip from '@/components/dispatch/availabilitysurgestrip';
 import LoadingScreen from '@/components/ui/loading-screen';
 import { normalizeLiteDraftToEvent, removeUndefinedDeep, toLiteDraftFromEvent } from '@/lib/liteEventAdapters';
 import { getRowStatusClass } from '@/lib/statusColors';
@@ -3102,6 +3103,8 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
 
                     <TeamActionButtonGroup selectedTab={selectedLeftTab as 'teams' | 'supervisors' | 'equipment'} />
                   </div>
+
+                  {event && <AvailabilitySurgeStrip event={event} />}
 
                   {/* Content with ScrollShadow */}
                   <div className="h-full overflow-auto scrollbar-hide">

--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -3398,9 +3398,10 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
 
           {/* Mobile/Tablet Layout - Bottom Tabs */}
           <div className="lg:hidden">
+            {event && <AvailabilitySurgeStrip event={event} />}
             {/* Background rectangle to cover bottom radius space */}
             <div className="fixed bottom-0 left-0 right-0 h-5 bg-surface-deep z-40"></div>
-            <Tabs 
+            <Tabs
               aria-label="Dispatch sections" 
               placement="bottom"
               radius="full"

--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -10,7 +10,7 @@ import AddSupervisorModal from "@/components/modals/event/addsupervisormodal";
 import React from 'react';
 import { dbService, ServiceError } from '@/lib/services';
 import { PostAssignment, Event, Staff, Supervisor, Call, EquipmentStatus, CallLogEntry, TeamLogEntry, EquipmentItem, EventEquipment, ClinicOutcome, Clinic } from '@/app/types';
-import { toast, Slide } from 'react-toastify';
+import { toast, Slide, ToastContainer } from 'react-toastify';
 import { useRouter } from 'next/navigation';
 import isEqual from 'lodash.isequal';
 import { useAuth } from '@/hooks/useauth';
@@ -30,6 +30,7 @@ import { ShieldAlert } from 'lucide-react';
 import { Select, SelectItem, Tabs, Tab, Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Tooltip } from "@heroui/react"
 import EquipmentCard from '@/components/dispatch/equipmentcard';
 import AvailabilitySurgeStrip from '@/components/dispatch/availabilitysurgestrip';
+import { getTeamAvailabilitySummary, getSurgeLimitPercent, isSurging } from '@/lib/teamAvailability';
 import LoadingScreen from '@/components/ui/loading-screen';
 import { normalizeLiteDraftToEvent, removeUndefinedDeep, toLiteDraftFromEvent } from '@/lib/liteEventAdapters';
 import { getRowStatusClass } from '@/lib/statusColors';
@@ -80,6 +81,29 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
   const vocabularyTerms = dispatchVocabularyPreset.terms;
   const t = useCallback((key: string) => vocabularyTerms[key] ?? key, [vocabularyTerms]);
   const router = useRouter();
+
+  const wasSurgingRef = useRef(false);
+  useEffect(() => {
+    if (!event) return;
+    const summary = getTeamAvailabilitySummary(event);
+    if (summary.total === 0) {
+      wasSurgingRef.current = false;
+      return;
+    }
+    const surging = isSurging(summary.percentOnCalls, getSurgeLimitPercent(event));
+    if (surging && !wasSurgingRef.current) {
+      toast.warning(`${t('Surge limit reached')} (${summary.percentOnCalls}%)`, {
+        position: 'top-right',
+        autoClose: 10000,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        transition: Slide,
+      });
+    }
+    wasSurgingRef.current = surging;
+  }, [event, t]);
+
   const [openCallId, setOpenCallId] = useState<string | null>(null);
   const [openClinicCallId, setOpenClinicCallId] = useState<string | null>(null);
   const [, setTeamToAdd] = useState<{ [callId: string]: string }>({});
@@ -2965,6 +2989,11 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
 
   return (
     <DispatchVocabularyProvider terms={vocabularyTerms}>
+      <ToastContainer
+        theme="dark"
+        toastClassName="!bg-surface-deep !border !border-surface-liner !rounded-2xl !text-surface-light !shadow-lg"
+        progressClassName="!bg-accent"
+      />
       {/* All your modals first - unchanged */}
       <QuickCallModal
         isOpen={showQuickCallForm}

--- a/src/app/lite/create/page.tsx
+++ b/src/app/lite/create/page.tsx
@@ -716,6 +716,27 @@ function LiteCreateContent() {
                 size="lg"
               />
             </div>
+            <div style={{ flex: 2 }}>
+              <Input
+                type="number"
+                label="Surge Limit"
+                labelPlacement="outside"
+                placeholder="70"
+                min={1}
+                max={100}
+                value={String(eventDraft.surgeLimitPercent ?? 70)}
+                onValueChange={(value) => {
+                  const parsed = Number(value);
+                  updateDraft((current) => ({
+                    ...current,
+                    surgeLimitPercent: Number.isFinite(parsed) ? Math.min(100, Math.max(1, parsed)) : current.surgeLimitPercent,
+                  }));
+                }}
+                endContent={<span className="text-surface-faint text-sm">%</span>}
+                classNames={inputClassNames}
+                size="lg"
+              />
+            </div>
             <div className="flex-shrink-0">
               <Button
                 onPress={handleCreateLiteEvent}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -63,6 +63,9 @@ export interface Event {
   end?: string | number;
 
   interactionSessions?: InteractionSession[];
+
+  /** Percent of teams actively on calls at which the surge display turns red. Defaults to 70 when unset. */
+  surgeLimitPercent?: number;
 }
 
 export interface TeamLogEntry {

--- a/src/components/dispatch/availabilitysurgestrip.tsx
+++ b/src/components/dispatch/availabilitysurgestrip.tsx
@@ -23,11 +23,18 @@ function surgeColor(positionPercent: number, surgeLimitPercent: number): string 
   return `rgb(${r} ${g} ${b})`;
 }
 
-const BAR_COUNT = 20;
-// Deterministic height pattern so the meter reads as an equalizer rather than a flat volume bar.
-const BAR_HEIGHTS = Array.from({ length: BAR_COUNT }, (_, i) => 40 + Math.round(30 * Math.abs(Math.sin(i * 0.85))));
+const BAR_COUNT = 14;
 
 type Props = { event: Event };
+
+function CountPill({ colorClass, count, label }: { colorClass: string; count: number; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5" aria-label={`${count} ${label}`}>
+      <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colorClass}`} />
+      <span className="text-sm font-bold text-surface-light tabular-nums">{count}</span>
+    </div>
+  );
+}
 
 export default function AvailabilitySurgeStrip({ event }: Props) {
   const { t } = useDispatchTerms();
@@ -37,31 +44,28 @@ export default function AvailabilitySurgeStrip({ event }: Props) {
 
   return (
     <div
-      className="w-full flex items-center justify-between gap-4 px-3 py-2 border-b border-surface-liner"
+      className="w-full flex items-center justify-between gap-4 pl-2 pr-3 py-2 border-b border-surface-liner"
       data-testid="availability-surge-strip"
     >
-      <div className="flex items-center gap-2 text-xs text-surface-faint whitespace-nowrap min-w-0 overflow-hidden">
-        <span>{summary.available} {t('Available')}</span>
-        <span className="text-surface-liner">·</span>
-        <span>{summary.onBreakOrClinic} {t('On Break/Clinic')}</span>
-        <span className="text-surface-liner">·</span>
-        <span>{summary.onCalls} {t('On Calls')}</span>
+      <div className="flex items-center gap-3 shrink-0">
+        <CountPill colorClass="bg-status-green" count={summary.available} label={t('Available')} />
+        <CountPill colorClass="bg-status-blue" count={summary.onBreakOrClinic} label={t('On Break/Clinic')} />
+        <CountPill colorClass="bg-status-red" count={summary.onCalls} label={t('On Calls')} />
       </div>
 
       <div className="flex items-center gap-2 shrink-0">
-        <span className="text-sm font-semibold tabular-nums" style={{ color: percentColor }}>
+        <span className="text-sm font-bold tabular-nums" style={{ color: percentColor }}>
           {summary.percentOnCalls}%
         </span>
-        <div className="flex items-end gap-[2px] h-4" aria-hidden="true">
-          {BAR_HEIGHTS.map((height, i) => {
+        <div className="flex items-center gap-[3px] h-5" aria-hidden="true">
+          {Array.from({ length: BAR_COUNT }, (_, i) => {
             const positionPercent = ((i + 1) / BAR_COUNT) * 100;
             const lit = positionPercent <= summary.percentOnCalls;
             return (
               <div
                 key={i}
-                className="w-[3px] rounded-full transition-opacity duration-300"
+                className="w-[4px] h-full rounded-sm transition-opacity duration-300"
                 style={{
-                  height: `${height}%`,
                   backgroundColor: surgeColor(positionPercent, surgeLimitPercent),
                   opacity: lit ? 1 : 0.25,
                 }}

--- a/src/components/dispatch/availabilitysurgestrip.tsx
+++ b/src/components/dispatch/availabilitysurgestrip.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import type { Event } from '@/app/types';
+import { getTeamAvailabilitySummary, getSurgeLimitPercent } from '@/lib/teamAvailability';
+import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
+
+// Must stay in sync with tailwind.config.js `status.green` / `status.red`.
+// Used raw (not as Tailwind classes) because the strip needs a continuous
+// interpolation between the two, not one of the discrete STATUS_COLORS entries.
+const STATUS_GREEN = { r: 0x98, g: 0xc3, b: 0x79 };
+const STATUS_RED = { r: 0xe5, g: 0x6a, b: 0x6a };
+
+function surgeColor(positionPercent: number, surgeLimitPercent: number): string {
+  if (positionPercent <= surgeLimitPercent) {
+    return `rgb(${STATUS_GREEN.r} ${STATUS_GREEN.g} ${STATUS_GREEN.b})`;
+  }
+  const span = Math.max(1, 100 - surgeLimitPercent);
+  const t = Math.min(1, (positionPercent - surgeLimitPercent) / span);
+  const r = Math.round(STATUS_GREEN.r + (STATUS_RED.r - STATUS_GREEN.r) * t);
+  const g = Math.round(STATUS_GREEN.g + (STATUS_RED.g - STATUS_GREEN.g) * t);
+  const b = Math.round(STATUS_GREEN.b + (STATUS_RED.b - STATUS_GREEN.b) * t);
+  return `rgb(${r} ${g} ${b})`;
+}
+
+const BAR_COUNT = 20;
+// Deterministic height pattern so the meter reads as an equalizer rather than a flat volume bar.
+const BAR_HEIGHTS = Array.from({ length: BAR_COUNT }, (_, i) => 40 + Math.round(30 * Math.abs(Math.sin(i * 0.85))));
+
+type Props = { event: Event };
+
+export default function AvailabilitySurgeStrip({ event }: Props) {
+  const { t } = useDispatchTerms();
+  const summary = useMemo(() => getTeamAvailabilitySummary(event), [event]);
+  const surgeLimitPercent = useMemo(() => getSurgeLimitPercent(event), [event]);
+  const percentColor = surgeColor(summary.percentOnCalls, surgeLimitPercent);
+
+  return (
+    <div
+      className="w-full flex items-center justify-between gap-4 px-3 py-2 border-b border-surface-liner"
+      data-testid="availability-surge-strip"
+    >
+      <div className="flex items-center gap-2 text-xs text-surface-faint whitespace-nowrap min-w-0 overflow-hidden">
+        <span>{summary.available} {t('Available')}</span>
+        <span className="text-surface-liner">·</span>
+        <span>{summary.onBreakOrClinic} {t('On Break/Clinic')}</span>
+        <span className="text-surface-liner">·</span>
+        <span>{summary.onCalls} {t('On Calls')}</span>
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        <span className="text-sm font-semibold tabular-nums" style={{ color: percentColor }}>
+          {summary.percentOnCalls}%
+        </span>
+        <div className="flex items-end gap-[2px] h-4" aria-hidden="true">
+          {BAR_HEIGHTS.map((height, i) => {
+            const positionPercent = ((i + 1) / BAR_COUNT) * 100;
+            const lit = positionPercent <= summary.percentOnCalls;
+            return (
+              <div
+                key={i}
+                className="w-[3px] rounded-full transition-opacity duration-300"
+                style={{
+                  height: `${height}%`,
+                  backgroundColor: surgeColor(positionPercent, surgeLimitPercent),
+                  opacity: lit ? 1 : 0.25,
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dispatch/availabilitysurgestrip.tsx
+++ b/src/components/dispatch/availabilitysurgestrip.tsx
@@ -31,7 +31,7 @@ function CountPill({ colorClass, count, label }: { colorClass: string; count: nu
   return (
     <div className="flex items-center gap-1.5" aria-label={`${count} ${label}`}>
       <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colorClass}`} />
-      <span className="text-sm font-bold text-surface-light tabular-nums">{count}</span>
+      <span className="text-sm text-surface-light tabular-nums">{count}</span>
     </div>
   );
 }

--- a/src/components/event-create/MetadataSection.tsx
+++ b/src/components/event-create/MetadataSection.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react';
 import { DateValue } from '@internationalized/date';
-import { DatePicker, Input } from '@heroui/react';
+import { DatePicker, Input, Tooltip } from '@heroui/react';
+import { CircleHelp } from 'lucide-react';
 import type { Event } from '@/app/types';
 
 type Props = {
@@ -35,41 +36,49 @@ export default function MetadataSection({
           size="lg"
         />
       </div>
-      <div>
-        <DatePicker
-          label="Event Date"
-          labelPlacement="outside"
-          value={getCalendarDate()}
-          onChange={(date) => {
-            if (date) {
-              setEventData((prev) => ({ ...prev, date: date.toString() }));
+      <div className="flex items-end gap-4">
+        <div className="flex-1">
+          <DatePicker
+            label="Event Date"
+            labelPlacement="outside"
+            value={getCalendarDate()}
+            onChange={(date) => {
+              if (date) {
+                setEventData((prev) => ({ ...prev, date: date.toString() }));
+              }
+            }}
+            classNames={inputClassNames}
+            size="lg"
+          />
+        </div>
+        <div className="flex-1">
+          <Input
+            type="number"
+            label={
+              <span className="inline-flex items-center gap-1">
+                Surge Limit
+                <Tooltip content="Percent of teams on calls at which the dispatch board's surge display turns red." placement="top">
+                  <CircleHelp className="w-3.5 h-3.5 text-surface-faint" />
+                </Tooltip>
+              </span>
             }
-          }}
-          classNames={inputClassNames}
-          size="lg"
-        />
-      </div>
-      <div>
-        <Input
-          type="number"
-          label="Surge Limit"
-          labelPlacement="outside"
-          placeholder="70"
-          min={1}
-          max={100}
-          value={String(eventData.surgeLimitPercent ?? 70)}
-          onValueChange={(value) => {
-            const parsed = Number(value);
-            setEventData((prev) => ({
-              ...prev,
-              surgeLimitPercent: Number.isFinite(parsed) ? Math.min(100, Math.max(1, parsed)) : prev.surgeLimitPercent,
-            }));
-          }}
-          endContent={<span className="text-surface-faint text-sm">%</span>}
-          description="Percent of teams on calls at which the dispatch board's surge display turns red."
-          classNames={inputClassNames}
-          size="lg"
-        />
+            labelPlacement="outside"
+            placeholder="70"
+            min={1}
+            max={100}
+            value={String(eventData.surgeLimitPercent ?? 70)}
+            onValueChange={(value) => {
+              const parsed = Number(value);
+              setEventData((prev) => ({
+                ...prev,
+                surgeLimitPercent: Number.isFinite(parsed) ? Math.min(100, Math.max(1, parsed)) : prev.surgeLimitPercent,
+              }));
+            }}
+            endContent={<span className="text-surface-faint text-sm">%</span>}
+            classNames={inputClassNames}
+            size="lg"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/event-create/MetadataSection.tsx
+++ b/src/components/event-create/MetadataSection.tsx
@@ -49,6 +49,28 @@ export default function MetadataSection({
           size="lg"
         />
       </div>
+      <div>
+        <Input
+          type="number"
+          label="Surge Limit"
+          labelPlacement="outside"
+          placeholder="70"
+          min={1}
+          max={100}
+          value={String(eventData.surgeLimitPercent ?? 70)}
+          onValueChange={(value) => {
+            const parsed = Number(value);
+            setEventData((prev) => ({
+              ...prev,
+              surgeLimitPercent: Number.isFinite(parsed) ? Math.min(100, Math.max(1, parsed)) : prev.surgeLimitPercent,
+            }));
+          }}
+          endContent={<span className="text-surface-faint text-sm">%</span>}
+          description="Percent of teams on calls at which the dispatch board's surge display turns red."
+          classNames={inputClassNames}
+          size="lg"
+        />
+      </div>
     </div>
   );
 }

--- a/src/lib/dispatchVocabulary/presets.ts
+++ b/src/lib/dispatchVocabulary/presets.ts
@@ -150,6 +150,9 @@ const CROWDCAD_FRENCH_TERMS: Record<string, string> = {
   Venues: 'Sites',
   'Clear Event': "Réinitialiser l'événement",
   'Export Summary': 'Exporter le résumé',
+  'On Calls': 'En intervention',
+  'On Break/Clinic': 'En pause/clinique',
+  'Surge limit reached': "Seuil d'affluence atteint",
 };
 
 export const BUILTIN_PRESETS: Record<BuiltinPresetId, DispatchVocabularyPresetSummary> = {

--- a/src/lib/dispatchVocabulary/terms.ts
+++ b/src/lib/dispatchVocabulary/terms.ts
@@ -165,6 +165,9 @@ export const DISPATCH_TERMS: DispatchTerm[] = [
     'Venues',
     'Clear Event',
     'Export Summary',
+    'On Calls',
+    'On Break/Clinic',
+    'Surge limit reached',
   ]),
 ];
 

--- a/src/lib/liteEventAdapters.ts
+++ b/src/lib/liteEventAdapters.ts
@@ -48,6 +48,7 @@ export function normalizeLiteDraftToEvent(draft: LiteEventDraft): Event {
     eventEquipment: draft.eventEquipment || [],
     postAssignments: draft.postAssignments || {},
     pendingAssignments: draft.pendingAssignments || {},
+    surgeLimitPercent: draft.surgeLimitPercent,
   };
 }
 
@@ -72,6 +73,7 @@ export function toLiteDraftFromEvent(nextEvent: Event, previousDraft: LiteEventD
     status: nextEvent.status ?? previousDraft.status ?? 'active',
     postAssignments: nextEvent.postAssignments || {},
     pendingAssignments: nextEvent.pendingAssignments || {},
+    surgeLimitPercent: nextEvent.surgeLimitPercent ?? previousDraft.surgeLimitPercent,
     createdAt:
       typeof nextEvent.createdAt === 'string' ? nextEvent.createdAt : previousDraft.createdAt,
     updatedAt: new Date().toISOString(),

--- a/src/lib/liteEventStore.ts
+++ b/src/lib/liteEventStore.ts
@@ -52,6 +52,7 @@ export interface LiteEventDraft {
   status: 'draft' | 'active';
   createdAt: string;
   updatedAt: string;
+  surgeLimitPercent?: number;
 }
 
 function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
@@ -169,6 +170,7 @@ export function createDefaultLiteEventDraft(eventId: string, eventName = ''): Li
     status: 'draft',
     createdAt: now,
     updatedAt: now,
+    surgeLimitPercent: 70,
   };
 }
 

--- a/src/lib/teamAvailability.ts
+++ b/src/lib/teamAvailability.ts
@@ -1,0 +1,58 @@
+import type { Event } from '@/app/types';
+import { deriveTeamVisualStatus } from '@/lib/statusColors';
+
+export const DEFAULT_SURGE_LIMIT_PERCENT = 70;
+
+const ON_CALL_STATUSES = new Set(['En Route', 'On Scene', 'Transporting', 'En Route Eq', 'Assisting']);
+const BREAK_OR_CLINIC_STATUSES = new Set(['On Break', 'In Clinic']);
+
+export interface TeamAvailabilitySummary {
+  total: number;
+  available: number;
+  onBreakOrClinic: number;
+  onCalls: number;
+  /** Teams in a transitional/resolution status (e.g. Delivered, Refusal) — counted in `total` but not in the three buckets above. */
+  other: number;
+  /** Rounded 0-100. */
+  percentOnCalls: number;
+}
+
+/**
+ * Buckets every team's current visual status (i.e. cross-checked against
+ * live call assignments via `deriveTeamVisualStatus`, not the raw possibly-stale
+ * `staff.status`) into Available / On Break-Clinic / On Calls for the dispatch
+ * sidebar's availability strip.
+ */
+export function getTeamAvailabilitySummary(event: Event): TeamAvailabilitySummary {
+  const staff = event.staff || [];
+  const total = staff.length;
+
+  let available = 0;
+  let onBreakOrClinic = 0;
+  let onCalls = 0;
+
+  for (const member of staff) {
+    const visualStatus = deriveTeamVisualStatus(member.status, event, member.team);
+    if (ON_CALL_STATUSES.has(visualStatus)) {
+      onCalls += 1;
+    } else if (BREAK_OR_CLINIC_STATUSES.has(visualStatus)) {
+      onBreakOrClinic += 1;
+    } else if (visualStatus === 'Available') {
+      available += 1;
+    }
+  }
+
+  const other = total - available - onBreakOrClinic - onCalls;
+  const percentOnCalls = total > 0 ? Math.round((onCalls / total) * 100) : 0;
+
+  return { total, available, onBreakOrClinic, onCalls, other, percentOnCalls };
+}
+
+export function getSurgeLimitPercent(event: Event): number {
+  const value = event.surgeLimitPercent;
+  return typeof value === 'number' && Number.isFinite(value) ? value : DEFAULT_SURGE_LIMIT_PERCENT;
+}
+
+export function isSurging(percentOnCalls: number, surgeLimitPercent: number): boolean {
+  return percentOnCalls >= surgeLimitPercent;
+}


### PR DESCRIPTION
Closes #21

## Summary
- Adds a configurable per-event **Surge Limit** (default 70%), set on the event create/edit page (cloud + lite), stored on `Event.surgeLimitPercent`.
- Adds an **availability/surge strip** to the dispatch board's left sidebar, directly under the Teams/Supervisors/Equipment selector (desktop and mobile/tablet): minimal colored-dot counts (green/blue/red = Available/On Break-Clinic/On Calls) on the left, and a percent-on-calls readout + equalizer-style meter on the right whose green-to-red gradient pivots at the surge limit rather than a fixed 0–100% split.
- Fires a **toast notification** the moment percent-on-calls crosses the surge limit (edge-triggered, not on every re-render while surging). This also fixes `ToastContainer` never being mounted anywhere in the app, so every existing `toast.*()` call was previously a silent no-op.
- Event Date and Surge Limit render side by side on the create page, with a tooltip (question-mark icon) explaining the surge limit instead of inline description text.

## Commits
- `feat(surge): add configurable surge limit field to event settings`
- `feat(surge): add team availability aggregation utility`
- `feat(surge): add availability/surge strip to dispatch sidebar`
- `style(surge): refine availability strip aesthetics`
- `feat(surge): add surge-limit toast notifications`
- `feat(surge): show availability strip on mobile/tablet dispatch layout`
- `style(surge): polish event-create surge limit field and strip counts`

## Test plan
- [x] `tsc --noEmit` and `eslint` clean on all changed files
- [x] Manually verified in the lite dispatch board (seeded via IndexedDB and via the actual Add Team/Add Call UI flow): counts and percentage correct, green below the limit, red above it, colors interpolate from the configured surge limit
- [x] Toast fires at the exact moment 7/10 teams crossed the 70% default limit (assigned via real Add Call flow), themed to match dispatch's dark surface chrome
- [x] Strip confirmed present and correctly scoped in both the desktop and mobile/tablet DOM containers
- [x] Verified the Event Date / Surge Limit side-by-side layout and tooltip via a temporary local-only preview route (cloud create page requires Firebase auth unavailable in this environment)
- [ ] Manual smoke test against a real authenticated cloud event

🤖 Generated with [Claude Code](https://claude.com/claude-code)