### PR TITLE
Multiple clinics: destination picker, schema persistence, and consistent icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Multiple named clinics (complete)** — follow-up to the 1.4.0 foundation. `events.clinics` is now a real, schema-backed field (was silently dropped on PocketBase before) and is kept in sync with the venue's clinic-flagged posts via stable per-post `clinicId`s that survive a clinic being renamed. When a team is marked Transporting on a multi-clinic event, dispatch now prompts for which clinic the team is heading to instead of always routing to the first one; the chosen clinic is written onto the call immediately. Team-status pills, call chips, resolved/"Delivered" chips, activity logs, and the venue map's team tooltip all reflect the destination clinic; single-clinic events are visually unchanged. Map-builder clinic markers (canvas, location list, and the dispatch-side venue map) now consistently use a clinic icon driven by the real `isClinic` flag instead of a name-string heuristic in one of the three spots.
+
 ---
 
 ## [1.4.0] - 2026-08-11

--- a/docs/ICD.md
+++ b/docs/ICD.md
@@ -151,8 +151,11 @@ PocketBase stores these as opaque `json` fields with no server-side schema; the 
 | `name` | string | Post name. |
 | `x`, `y` | number \| null | Position as a percentage of map width/height. |
 | `isClinic` | bool (optional) | Marks this post as a clinic. |
+| `clinicId` | string (optional) | Stable id, generated once when `isClinic` first becomes true. Survives the post being renamed later; used to match this post against `events.clinics` entries. |
 
 **`Layer`**: `id`, `name`, `mapUrl?`, `posts: Post[]`.
+
+**`Clinic`**: `id` (matches a clinic-flagged `Post.clinicId`), `name` (kept in sync with that post's current name). `events.clinics: Clinic[]` is populated additively from the event's `venue.posts` — see `src/lib/clinics.ts`'s `syncClinicsFromVenue`.
 
 **`Equipment`** (venue-level): `id`, `name`, `status` (free-text status string), `assignedTeam?`, `location?`.
 
@@ -196,7 +199,9 @@ PocketBase stores these as opaque `json` fields with no server-side schema; the 
 
 ## 4. Fields present in the app's TypeScript types but not in this PocketBase schema
 
-`src/app/types.ts`'s `Event` interface also declares `createdAt`, `ended`, `clinics`, `postingStart`/`postingEnd`, `scheduleStart`/`scheduleEnd`, `startTime`/`endTime`, and `start`/`end`. None of these appear in the `events` collection's actual field list (`scripts/setup-pocketbase.js`, `tests/e2e/pb_migrations/…created_events.js`). CrowdCAD supports both a Firebase and a PocketBase backend behind a common interface, and these fields appear to be write-only leftovers for the Firebase path: since PocketBase silently drops unknown fields on create/update (§2.2), sending them to a PocketBase-backed deployment has no effect — they will not be persisted or returned. Do not rely on them being present in PocketBase `events` records.
+`src/app/types.ts`'s `Event` interface also declares `createdAt`, `ended`, `postingStart`/`postingEnd`, `scheduleStart`/`scheduleEnd`, `startTime`/`endTime`, and `start`/`end`. None of these appear in the `events` collection's actual field list (`scripts/setup-pocketbase.js`, `tests/e2e/pb_migrations/…created_events.js`). CrowdCAD supports both a Firebase and a PocketBase backend behind a common interface, and these fields appear to be write-only leftovers for the Firebase path: since PocketBase silently drops unknown fields on create/update (§2.2), sending them to a PocketBase-backed deployment has no effect — they will not be persisted or returned. Do not rely on them being present in PocketBase `events` records.
+
+`clinics` **is** a schema-backed `json` field on `events` (added alongside multi-clinic support) — it does persist on PocketBase.
 
 ## 5. Notes
 

--- a/scripts/setup-pocketbase.js
+++ b/scripts/setup-pocketbase.js
@@ -169,7 +169,12 @@ async function main() {
     { name: 'pendingAssignments', type: 'json' },
     { name: 'postAssignments', type: 'json' },
     { name: 'interactionSessions', type: 'json' },
+    { name: 'clinics', type: 'json' },
   ]);
+
+  // `clinics` on `events` — set for deployments where this collection
+  // already existed before the field was added above.
+  await ensureField(headers, 'events', { name: 'clinics', type: 'json' });
 
   await ensureCollection(headers, 'dispatchLogs', [
     { name: 'eventId', type: 'text' },

--- a/src/app/(main)/events/[eventId]/create/page.tsx
+++ b/src/app/(main)/events/[eventId]/create/page.tsx
@@ -9,6 +9,7 @@ import { Tabs, Tab, Button, Card, ScrollShadow } from '@heroui/react';
 import { parseDate, getLocalTimeZone, today } from '@internationalized/date';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { DiagonalStreaksFixed } from "@/components/ui/diagonal-streaks-fixed";
+import { syncClinicsFromVenue } from '@/lib/clinics';
 import MapZoomControls from '@/components/ui/map-zoom-controls';
 import MapPanSurface from '@/components/ui/map-pan-surface';
 import { useScheduleGeneration } from '@/hooks/useScheduleGeneration';
@@ -355,6 +356,9 @@ export default function EventCreation() {
       const computedTimes = postingTimes;
       console.log('handleSubmit computed postingTimes:', computedTimes, 'eventData.postingTimes:', eventData.postingTimes);
 
+      // Populate clinics from venue-designated clinic posts right before save.
+      const computedClinics = syncClinicsFromVenue(eventData.venue, eventData.clinics);
+
       let eventDocId = eventId;
       if (eventDocId) {
         try {
@@ -363,6 +367,7 @@ export default function EventCreation() {
             await dbService.updateDocument('events', eventDocId, stripUndefined({
               ...eventData,
               postingTimes: computedTimes.length > 0 ? computedTimes : eventData.postingTimes,
+              clinics: computedClinics,
               userId: user.uid,
               date: dateValue.toISOString(),
               updatedAt: new Date().toISOString(),
@@ -374,6 +379,7 @@ export default function EventCreation() {
             eventDocId = await dbService.addDocument('events', stripUndefined({
               ...eventData,
               postingTimes: computedTimes.length > 0 ? computedTimes : eventData.postingTimes,
+              clinics: computedClinics,
               userId: user.uid,
               date: dateValue.toISOString(),
               createdAt: new Date().toISOString(),
@@ -386,6 +392,7 @@ export default function EventCreation() {
           console.error('Error checking/updating document:', error);
           eventDocId = await dbService.addDocument('events', stripUndefined({
             ...eventData,
+            clinics: computedClinics,
             userId: user.uid,
             date: dateValue.toISOString(),
             createdAt: new Date().toISOString(),
@@ -397,6 +404,7 @@ export default function EventCreation() {
       } else {
         eventDocId = await dbService.addDocument('events', stripUndefined({
           ...eventData,
+          clinics: computedClinics,
           userId: user.uid,
           date: dateValue.toISOString(),
           createdAt: new Date().toISOString(),

--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -34,10 +34,9 @@ import { getTeamAvailabilitySummary, getSurgeLimitPercent, isSurging } from '@/l
 import LoadingScreen from '@/components/ui/loading-screen';
 import { normalizeLiteDraftToEvent, removeUndefinedDeep, toLiteDraftFromEvent } from '@/lib/liteEventAdapters';
 import { getRowStatusClass } from '@/lib/statusColors';
+import { syncClinicsFromVenue, getEventClinics, getClinicName } from '@/lib/clinics';
 import { useDispatchVocabulary } from '@/hooks/useDispatchVocabulary';
 import { DispatchVocabularyProvider } from '@/lib/dispatchVocabulary/context';
-
-const DEFAULT_CLINICS: Clinic[] = [{ id: 'clinic', name: 'Clinic' }];
 
 interface DispatchRoutePageProps {
   params: Promise<{ eventId: string }>;
@@ -1111,7 +1110,7 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
   }, [event]);
 
 
-  const handleTeamStatusChange = (callId: string, team: string, newStatus: string) => {
+  const handleTeamStatusChange = (callId: string, team: string, newStatus: string, clinicId?: string) => {
     console.log("FUNCTION CALLED", { callId, team, newStatus });
     setTeamStatusMap(prev => {
       const updatedStatusMap = { ...prev };
@@ -1135,8 +1134,12 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
 
     const now = new Date();
     const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
-    const logMessage = `${hhmm} - ${team} set to ${newStatus}`;
-    
+    const resolvedClinicId = clinicId ?? latestCall.clinicId ?? (event?.clinics?.[0]?.id || 'clinic');
+    const destinationClinicName = ['Transporting', 'Delivered'].includes(newStatus)
+      ? getClinicName(clinics, resolvedClinicId)
+      : undefined;
+    const logMessage = `${hhmm} - ${team} set to ${newStatus}${destinationClinicName ? ` (${destinationClinicName})` : ''}`;
+
     // DECLARE newCallStatus here with proper initialization
     let newCallStatus = latestCall.status; // Initialize with current status
     
@@ -1242,7 +1245,7 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
         ...c,
         status: displayStatus,
         clinic: clinicFlag,
-        clinicId: c.clinicId ?? (event?.clinics?.[0]?.id || 'clinic'),
+        clinicId: resolvedClinicId,
         log: updatedLog,
         assignedTeam: updatedAssignedTeam,
         equipmentTeams: updatedEquipmentTeams,
@@ -1554,7 +1557,17 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
     );
     return () => unsubscribe();
   }, [eventId, user, router, isAdmin, isLiteMode]);
-  
+
+  // Lazily backfill/refresh event.clinics from the venue's clinic-flagged posts
+  // (additive — never removes an entry, so existing calls' clinicId never orphans).
+  useEffect(() => {
+    if (!event) return;
+    const synced = syncClinicsFromVenue(event.venue, event.clinics);
+    if (!isEqual(synced, event.clinics || [])) {
+      void updateEvent({ clinics: synced });
+    }
+  }, [event, updateEvent]);
+
   const handleRemoveTeamFromCall = async (callId: string, teamToRemove: string) => {
     if (!event) return;
     
@@ -1809,21 +1822,28 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
     };
   }, []);
 
-  const handleStatusChange = useCallback(async (staff: Staff, newStatus: string) => {
+  const handleStatusChange = useCallback(async (staff: Staff, newStatus: string, clinicId?: string) => {
     const team = staff.team;
 
     setTeamTimers(prev => ({ ...prev, [team]: Date.now() }));
 
     await updateEvent((currentEvent) => {
 
-      const callId = currentEvent.calls.find(c => 
-        c.assignedTeam?.includes(team) && 
-        !['Resolved', 'Available'].includes(c.status) 
-      )?.id;
+      const activeCall = currentEvent.calls.find(c =>
+        c.assignedTeam?.includes(team) &&
+        !['Resolved', 'Available'].includes(c.status)
+      );
+      const callId = activeCall?.id;
 
       const now = new Date();
       const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
-      const logMessage = `${hhmm} - ${team} set to ${newStatus}`;
+      const resolvedClinicId = newStatus === 'Transporting'
+        ? (clinicId ?? activeCall?.clinicId ?? currentEvent.clinics?.[0]?.id ?? 'clinic')
+        : activeCall?.clinicId;
+      const destinationClinicName = newStatus === 'Transporting'
+        ? getClinicName(getEventClinics(currentEvent.clinics), resolvedClinicId)
+        : undefined;
+      const logMessage = `${hhmm} - ${team} set to ${newStatus}${destinationClinicName ? ` (${destinationClinicName})` : ''}`;
 
       const updatedStaff = (currentEvent.staff || []).map(s => {
         if (s.team !== team) return s;
@@ -1860,6 +1880,7 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
             return {
                 ...c,
                 status: newCallStatus,
+                clinicId: newStatus === 'Transporting' ? resolvedClinicId : c.clinicId,
                 log: [...(c.log || []), { timestamp: now.getTime(), message: logMessage }]
             };
          });
@@ -2787,7 +2808,7 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
 
   // Venue-designated clinics, falling back to a single default "Clinic" for
   // events created before multi-clinic support existed.
-  const clinics: Clinic[] = event.clinics && event.clinics.length > 0 ? event.clinics : DEFAULT_CLINICS;
+  const clinics: Clinic[] = getEventClinics(event.clinics);
 
   // Calls delivered before per-clinic routing existed (or with no clinicId set) all
   // land in the first/default clinic, so nothing gets silently hidden or duplicated.
@@ -3810,6 +3831,8 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
               staff={event.staff || []}
               equipment={event.eventEquipment || []}
               teamTimers={teamTimers}
+              calls={event.calls || []}
+              clinics={clinics}
             />
           )}
 

--- a/src/app/(main)/venues/management/page.client.tsx
+++ b/src/app/(main)/venues/management/page.client.tsx
@@ -10,6 +10,8 @@ import { dbService, storageService } from '@/lib/services';
 import type { Post, Venue, Equipment, EquipmentStatus, Layer } from '@/app/types';
 import { DiagonalStreaksFixed } from "@/components/ui/diagonal-streaks-fixed";
 import { isPointWithinRect, pixelToPercent } from '@/lib/markerUtils';
+import { hasDuplicateClinicName, isClinicPost } from '@/lib/clinics';
+import { stripUndefined } from '@/lib/utils';
 import { uploadWithRetry } from '@/lib/uploadUtils';
 import { useZoomPan } from '@/hooks/useZoomPan';
 import NewLayerModal from '@/components/modals/venue/newlayer';
@@ -36,6 +38,7 @@ import {
   Trash2, 
   Edit2,
   MapPinned,
+  HousePlus,
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react';
@@ -353,12 +356,23 @@ export default function VenueManagementPageClient() {
       return;
     }
 
+    if (markerIsClinicInput && hasDuplicateClinicName(name, allPosts, { layerIdx: pendingMarker.layerIdx, postIdx: pendingMarker.postIdx })) {
+      alert('Another clinic already uses this name. Give each clinic a unique name.');
+      return;
+    }
+
     setVenueData((prev) => {
       const newLayers = [...prev.layers];
       const copy = [...newLayers[pendingMarker.layerIdx].posts];
       const currentPost = copy[pendingMarker.postIdx];
       if (typeof currentPost !== 'string') {
-        copy[pendingMarker.postIdx] = { ...currentPost, name, isClinic: markerIsClinicInput };
+        const clinicId = markerIsClinicInput ? (currentPost.clinicId || crypto.randomUUID()) : currentPost.clinicId;
+        copy[pendingMarker.postIdx] = {
+          ...currentPost,
+          name,
+          isClinic: markerIsClinicInput,
+          ...(clinicId ? { clinicId } : {}),
+        };
       }
       newLayers[pendingMarker.layerIdx] = { ...newLayers[pendingMarker.layerIdx], posts: copy };
       return { ...prev, layers: newLayers };
@@ -398,18 +412,26 @@ export default function VenueManagementPageClient() {
   const handleEditLocation = (name: string, newLayerIdx: number, isClinic: boolean) => {
     if (!editingLocation) return;
     const { layerIdx, postIdx } = editingLocation;
+
+    if (isClinic && hasDuplicateClinicName(name, allPosts, { layerIdx, postIdx })) {
+      alert('Another clinic already uses this name. Give each clinic a unique name.');
+      return;
+    }
+
     setVenueData((prev) => {
       const newLayers = [...prev.layers];
       const post = newLayers[layerIdx].posts[postIdx];
       if (typeof post === 'string') return prev;
+      const clinicId = isClinic ? (post.clinicId || crypto.randomUUID()) : post.clinicId;
+      const clinicIdField = clinicId ? { clinicId } : {};
       if (newLayerIdx !== layerIdx) {
         // Move to new layer
-        const newPost = { ...post, name, isClinic };
+        const newPost = { ...post, name, isClinic, ...clinicIdField };
         newLayers[layerIdx].posts.splice(postIdx, 1);
         newLayers[newLayerIdx].posts.push(newPost);
       } else {
         // Same layer, just rename
-        newLayers[layerIdx].posts[postIdx] = { ...post, name, isClinic };
+        newLayers[layerIdx].posts[postIdx] = { ...post, name, isClinic, ...clinicIdField };
       }
       return { ...prev, layers: newLayers };
     });
@@ -467,6 +489,7 @@ export default function VenueManagementPageClient() {
       name: string;
       x: number;
       y: number;
+      isClinic?: boolean;
     };
 
     return venueData.layers[currentLayer].posts
@@ -506,7 +529,11 @@ export default function VenueManagementPageClient() {
                 renamePost(currentLayer, idx);
               }}
             >
-              <MapPin className="h-4 w-4 text-accent" strokeWidth={2.5} />
+              {post.isClinic ? (
+                <HousePlus className="h-4 w-4 text-accent" strokeWidth={2.5} />
+              ) : (
+                <MapPin className="h-4 w-4 text-accent" strokeWidth={2.5} />
+              )}
             </div>
             {isHover && !isPending && post.name && (
               <div
@@ -576,10 +603,12 @@ export default function VenueManagementPageClient() {
         dataToSave.mapUrl = venueData.layers[0].mapUrl;
       }
 
+      const sanitizedDataToSave = stripUndefined(dataToSave);
+
       if (venueId) {
-        await dbService.updateDocument('venues', venueId, dataToSave);
+        await dbService.updateDocument('venues', venueId, sanitizedDataToSave);
       } else {
-        await dbService.addDocument('venues', dataToSave);
+        await dbService.addDocument('venues', sanitizedDataToSave);
       }
       router.push('/venues/selection')
     } catch (error: unknown) {
@@ -737,7 +766,9 @@ export default function VenueManagementPageClient() {
                               >
                                 <div className="flex items-center justify-between px-3 py-2">
                                   <div className="flex items-center gap-2 flex-1 min-w-0">
-                                    {hasCoordinates ? (
+                                    {isClinicPost(post) ? (
+                                      <HousePlus className="h-4 w-4 flex-shrink-0 text-accent" />
+                                    ) : hasCoordinates ? (
                                       <MapPinned className="h-4 w-4 flex-shrink-0 text-accent" />
                                     ) : (
                                       <MapPin className="h-4 w-4 flex-shrink-0 text-surface-light" />

--- a/src/app/lite/create/page.tsx
+++ b/src/app/lite/create/page.tsx
@@ -32,6 +32,7 @@ import {
   saveLiteEvent,
 } from '@/lib/liteEventStore';
 import { formatTimeValue, parseTimeValue } from '@/lib/scheduleUtils';
+import { syncClinicsFromVenue } from '@/lib/clinics';
 import { useScheduleGeneration } from '@/hooks/useScheduleGeneration';
 import { useTeamForm } from '@/hooks/useTeamForm';
 
@@ -661,6 +662,7 @@ function LiteCreateContent() {
       ...eventDraft,
       status: 'active',
       updatedAt: new Date().toISOString(),
+      clinics: syncClinicsFromVenue(eventDraft.venue, eventDraft.clinics),
     };
 
     await saveLiteEvent(finalized);

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -5,6 +5,7 @@ export type Post =
     x: number | null; // percentage of width
     y: number | null; // percentage of height
     isClinic?: boolean;
+    clinicId?: string; // stable id, set once when isClinic first becomes true
   };
 
 export interface Clinic {

--- a/src/components/dispatch/calltracking.tsx
+++ b/src/components/dispatch/calltracking.tsx
@@ -18,6 +18,7 @@ import DispatchMotionCell from './motioncell';
 import TrackingTableBase from './trackingtablebase';
 import { getStatusColor, TEAM_CARD_ROW_HOVER_CLASS } from '@/lib/statusColors';
 import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
+import { getEventClinics, getTransportingLabel, getDeliveredLabel } from '@/lib/clinics';
 
 import {
   Dropdownmenu,
@@ -52,7 +53,7 @@ interface CallTrackingTableProps {
   handleMarkDuplicate: (callId: string) => void;
   handleTogglePriorityFromMenu: (callId: string) => void;
   handleDeleteCall: (callId: string) => void;
-  handleTeamStatusChange: (callId: string, team: string, newStatus: string) => void;
+  handleTeamStatusChange: (callId: string, team: string, newStatus: string, clinicId?: string) => void;
   handleRemoveTeamFromCall: (callId: string, team: string) => Promise<void>;
   handleAddTeamToCall: (callId: string, team: string) => Promise<void>;
   getCallRowClass: (call: Call) => string;
@@ -116,6 +117,7 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
   // never dismiss a menu that fast, so ignore closes inside this window
   // unless they came from an actual selection (onAction).
   const { t } = useDispatchTerms();
+  const clinics = getEventClinics(event.clinics);
   const TEAM_STATUS_MENU_CLOSE_GUARD_MS = 150;
   const teamStatusMenuOpenedAtRef = React.useRef<number>(0);
   const teamStatusMenuSelectedRef = React.useRef<boolean>(false);
@@ -406,47 +408,85 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                 >
                                   <div className="flex items-center gap-2" data-testid={`team-chip-${team}`}>
                                     <span>{team}</span>
-                                    <Dropdown
-                                      motionProps={dropdownMotionProps}
-                                      isOpen={openMenuToken === `team-status:${call.id}:${team}` && isMotionVisible}
-                                      onOpenChange={(isOpen) => {
-                                        if (isOpen) {
-                                          if (isResolvedCall && !showResolvedCalls) return;
-                                          teamStatusMenuOpenedAtRef.current = Date.now();
-                                          setOpenMenuToken(`team-status:${call.id}:${team}`);
-                                          return;
-                                        }
-                                        const selected = teamStatusMenuSelectedRef.current;
-                                        teamStatusMenuSelectedRef.current = false;
-                                        if (!selected && Date.now() - teamStatusMenuOpenedAtRef.current < TEAM_STATUS_MENU_CLOSE_GUARD_MS) {
-                                          return;
-                                        }
-                                        setOpenMenuToken((current) =>
-                                          current === `team-status:${call.id}:${team}` ? null : current
-                                        );
-                                      }}
-                                    >
-                                      <DropdownTrigger>
-                                        <Button
-                                          size="sm"
-                                          variant="light"
-                                          className="min-w-0 h-6 px-2 text-xs shrink-0"
-                                        >
-                                          {t(currentTeamStatus)}
-                                        </Button>
-                                      </DropdownTrigger>
-                                      <DropdownMenu
-                                        aria-label="Team status"
-                                        onAction={(key) => {
-                                          teamStatusMenuSelectedRef.current = true;
-                                          handleTeamStatusChange(call.id, team, key as string);
+                                    {openMenuToken === `team-clinic-pick:${call.id}:${team}` ? (
+                                      <Dropdown
+                                        motionProps={dropdownMotionProps}
+                                        isOpen={isMotionVisible}
+                                        onOpenChange={(isOpen) => {
+                                          if (isOpen) return;
+                                          setOpenMenuToken((current) =>
+                                            current === `team-clinic-pick:${call.id}:${team}` ? null : current
+                                          );
                                         }}
                                       >
-                                        {statusOptions.map((status: string) => (
-                                          <DropdownItem key={status}>{t(status)}</DropdownItem>
-                                        ))}
-                                      </DropdownMenu>
-                                    </Dropdown>
+                                        <DropdownTrigger>
+                                          <Button
+                                            size="sm"
+                                            variant="light"
+                                            className="min-w-0 h-6 px-2 text-xs shrink-0"
+                                          >
+                                            {t('Select clinic')}
+                                          </Button>
+                                        </DropdownTrigger>
+                                        <DropdownMenu
+                                          aria-label="Select destination clinic"
+                                          onAction={(key) => {
+                                            setOpenMenuToken(null);
+                                            handleTeamStatusChange(call.id, team, 'Transporting', key as string);
+                                          }}
+                                        >
+                                          {clinics.map((clinic) => (
+                                            <DropdownItem key={clinic.id}>{clinic.name}</DropdownItem>
+                                          ))}
+                                        </DropdownMenu>
+                                      </Dropdown>
+                                    ) : (
+                                      <Dropdown
+                                        motionProps={dropdownMotionProps}
+                                        isOpen={openMenuToken === `team-status:${call.id}:${team}` && isMotionVisible}
+                                        onOpenChange={(isOpen) => {
+                                          if (isOpen) {
+                                            if (isResolvedCall && !showResolvedCalls) return;
+                                            teamStatusMenuOpenedAtRef.current = Date.now();
+                                            setOpenMenuToken(`team-status:${call.id}:${team}`);
+                                            return;
+                                          }
+                                          const selected = teamStatusMenuSelectedRef.current;
+                                          teamStatusMenuSelectedRef.current = false;
+                                          if (!selected && Date.now() - teamStatusMenuOpenedAtRef.current < TEAM_STATUS_MENU_CLOSE_GUARD_MS) {
+                                            return;
+                                          }
+                                          setOpenMenuToken((current) =>
+                                            current === `team-status:${call.id}:${team}` ? null : current
+                                          );
+                                        }}
+                                      >
+                                        <DropdownTrigger>
+                                          <Button
+                                            size="sm"
+                                            variant="light"
+                                            className="min-w-0 h-6 px-2 text-xs shrink-0"
+                                          >
+                                            {currentTeamStatus === 'Transporting' ? getTransportingLabel(t, clinics, call.clinicId) : t(currentTeamStatus)}
+                                          </Button>
+                                        </DropdownTrigger>
+                                        <DropdownMenu
+                                          aria-label="Team status"
+                                          onAction={(key) => {
+                                            teamStatusMenuSelectedRef.current = true;
+                                            if (key === 'Transporting' && clinics.length > 1) {
+                                              setOpenMenuToken(`team-clinic-pick:${call.id}:${team}`);
+                                              return;
+                                            }
+                                            handleTeamStatusChange(call.id, team, key as string, key === 'Transporting' ? clinics[0]?.id : undefined);
+                                          }}
+                                        >
+                                          {statusOptions.map((status: string) => (
+                                            <DropdownItem key={status}>{t(status)}</DropdownItem>
+                                          ))}
+                                        </DropdownMenu>
+                                      </Dropdown>
+                                    )}
                                   </div>
                                 </Chip>
                               );
@@ -465,7 +505,7 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                   {detachedTeam.team}
                                 </span>
                                 <span className="text-xs">
-                                  {t(detachedTeam.reason)}
+                                  {detachedTeam.reason === 'Delivered' ? getDeliveredLabel(t, clinics, call.clinicId) : t(detachedTeam.reason)}
                                 </span>
                               </Chip>
                             ))}

--- a/src/components/dispatch/calltrackingcard.tsx
+++ b/src/components/dispatch/calltrackingcard.tsx
@@ -19,6 +19,7 @@ import {
 import type { Event, Call } from '@/app/types';
 import TrackingTextEntry from '@/components/dispatch/trackingtextentry';
 import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
+import { getEventClinics, getTransportingLabel, getDeliveredLabel } from '@/lib/clinics';
 
 type CallTrackingCardProps = {
   call: Call;
@@ -29,7 +30,7 @@ type CallTrackingCardProps = {
   onChiefComplaintChange: (callId: string, chiefComplaint: string) => void;
   onRemoveTeamFromCall: (callId: string, team: string) => Promise<void>;
   onAddTeamToCall: (callId: string, team: string) => Promise<void>;
-  handleTeamStatusChange: (callId: string, team: string, newStatus: string) => void;
+  handleTeamStatusChange: (callId: string, team: string, newStatus: string, clinicId?: string) => void;
   handleMarkDuplicate: (callId: string) => void;
   handleTogglePriority: (callId: string) => void;
   handleDeleteCall: (callId: string) => void;
@@ -92,6 +93,8 @@ export default function CallTrackingCard({
   updateEvent,
 }: CallTrackingCardProps) {
   const { t } = useDispatchTerms();
+  const clinics = getEventClinics(event.clinics);
+  const [clinicPickTeam, setClinicPickTeam] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
   const [locationInput, setLocationInput] = useState(call.location || '');
   const [ageSexInput, setAgeSexInput] = useState(formatAgeSex(call.age, call.gender) || '');
@@ -341,26 +344,64 @@ export default function CallTrackingCard({
               >
                 <div className="flex items-center gap-2" data-testid={`team-chip-${team}`}>
                   <span className="font-medium">{team}</span>
-                  <Dropdown motionProps={dropdownMotionProps} placement="bottom-end" offset={2}>
-                    <DropdownTrigger>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        className="text-xs text-surface-faint hover:text-surface-light transition-colors"
-                      >
-                        {t(currentStatus)} ▼
-                      </button>
-                    </DropdownTrigger>
-                    <DropdownMenu
-                      aria-label="Team Status"
-                      onAction={(key) => handleTeamStatusChange(call.id, team, key as string)}
+                  {clinicPickTeam === team ? (
+                    <Dropdown
+                      motionProps={dropdownMotionProps}
+                      placement="bottom-end"
+                      offset={2}
+                      isOpen
+                      onOpenChange={(isOpen) => {
+                        if (!isOpen) setClinicPickTeam(null);
+                      }}
                     >
-                      {statusOptions.map(status => (
-                        <DropdownItem key={status}>{t(status)}</DropdownItem>
-                      ))}
-                    </DropdownMenu>
-                  </Dropdown>
+                      <DropdownTrigger>
+                        <button
+                          onClick={(e) => e.stopPropagation()}
+                          className="text-xs text-surface-faint hover:text-surface-light transition-colors"
+                        >
+                          {t('Select clinic')} ▼
+                        </button>
+                      </DropdownTrigger>
+                      <DropdownMenu
+                        aria-label="Select destination clinic"
+                        onAction={(key) => {
+                          setClinicPickTeam(null);
+                          handleTeamStatusChange(call.id, team, 'Transporting', key as string);
+                        }}
+                      >
+                        {clinics.map((clinic) => (
+                          <DropdownItem key={clinic.id}>{clinic.name}</DropdownItem>
+                        ))}
+                      </DropdownMenu>
+                    </Dropdown>
+                  ) : (
+                    <Dropdown motionProps={dropdownMotionProps} placement="bottom-end" offset={2}>
+                      <DropdownTrigger>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          className="text-xs text-surface-faint hover:text-surface-light transition-colors"
+                        >
+                          {currentStatus === 'Transporting' ? getTransportingLabel(t, clinics, call.clinicId) : t(currentStatus)} ▼
+                        </button>
+                      </DropdownTrigger>
+                      <DropdownMenu
+                        aria-label="Team Status"
+                        onAction={(key) => {
+                          if (key === 'Transporting' && clinics.length > 1) {
+                            setClinicPickTeam(team);
+                            return;
+                          }
+                          handleTeamStatusChange(call.id, team, key as string, key === 'Transporting' ? clinics[0]?.id : undefined);
+                        }}
+                      >
+                        {statusOptions.map(status => (
+                          <DropdownItem key={status}>{t(status)}</DropdownItem>
+                        ))}
+                      </DropdownMenu>
+                    </Dropdown>
+                  )}
                 </div>
               </Chip>
             );
@@ -379,7 +420,7 @@ export default function CallTrackingCard({
                 {detachedTeam.team}
               </span>
               <span className="text-xs">
-                {t(detachedTeam.reason)}
+                {detachedTeam.reason === 'Delivered' ? getDeliveredLabel(t, clinics, call.clinicId) : t(detachedTeam.reason)}
               </span>
             </Chip>
           ))}

--- a/src/components/dispatch/teamcard-condensed.tsx
+++ b/src/components/dispatch/teamcard-condensed.tsx
@@ -4,20 +4,21 @@
 import React, {useEffect, useMemo, useState, useRef} from 'react';
 import {
   Card, CardHeader, CardBody, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem,
-  Select, SelectItem, Autocomplete, AutocompleteItem
+  Select, SelectItem, Autocomplete, AutocompleteItem, Button
 } from '@heroui/react';
-import {ChevronDown, ChevronUp, MapPin, MoreVertical} from 'lucide-react';
+import {ChevronDown, ChevronUp, MapPin, MoreVertical, ArrowRight} from 'lucide-react';
 import type {Event, Staff} from '@/app/types';
 import TrackingTextEntry from '@/components/dispatch/trackingtextentry';
 import { deriveTeamVisualStatus, getStatusColor } from '@/lib/statusColors';
 import DispatchMotionCell from './motioncell';
 import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
+import { getEventClinics, getClinicName } from '@/lib/clinics';
 
 type TeamCardCondensedProps = {
   staff: Staff;
   event: Event;
   sinceMs?: number;
-  onStatusChange: (staff: Staff, newStatus: string) => void;
+  onStatusChange: (staff: Staff, newStatus: string, clinicId?: string) => void;
   onLocationChange: (staff: Staff, newLocation: string) => void;
   onEdit?: (staff: Staff) => void;
   onDelete?: (teamName: string) => void;
@@ -79,12 +80,16 @@ export default function TeamCardCondensed({
 
   const timer = useMMSS(sinceMs);
 
+  const [showClinicPicker, setShowClinicPicker] = useState(false);
+  const clinics = getEventClinics(event.clinics);
+
   // Status options
-  const isOnAnyActiveCall = !!event.calls?.some(c =>
+  const activeCall = event.calls?.find(c =>
     c.assignedTeam?.includes(staff.team) && !['Resolved','Delivered','Refusal','NMM'].includes(c.status)
   );
+  const isOnAnyActiveCall = !!activeCall;
 
-  const isOnEq = !!event.calls?.some(c => 
+  const isOnEq = !!event.calls?.some(c =>
     c.equipmentTeams?.includes(staff.team) && !['Resolved','Delivered Eq','Refusal','NMM'].includes(c.status)
   ) || ['En Route Eq', 'Assisting'].includes(staff.status);
 
@@ -132,8 +137,15 @@ export default function TeamCardCondensed({
           <span className="text-sm font-semibold text-surface-light truncate">
             {staff.team}
           </span>
-          <span className={`text-sm font-bold truncate ${statusTone.textClass}`}>
-            {t(staff.status)}
+          <span className={`text-sm font-bold truncate flex items-center gap-1 min-w-0 ${statusTone.textClass}`}>
+            {staff.status === 'Transporting' && getClinicName(clinics, activeCall?.clinicId) ? (
+              <>
+                <ArrowRight className="h-3.5 w-3.5 shrink-0" strokeWidth={3} />
+                <span className="truncate">{getClinicName(clinics, activeCall?.clinicId)}</span>
+              </>
+            ) : (
+              t(staff.status)
+            )}
           </span>
           <span className="text-sm text-surface-faint truncate">
             {staff.location ? t(staff.location) : t('No location')}
@@ -186,6 +198,34 @@ export default function TeamCardCondensed({
           <div className="flex items-center gap-3">
             {/* Status */}
             <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} className="min-w-0 flex-[1]">
+              {showClinicPicker ? (
+                <Dropdown
+                  isOpen
+                  onOpenChange={(isOpen) => {
+                    if (!isOpen) setShowClinicPicker(false);
+                  }}
+                >
+                  <DropdownTrigger>
+                    <Button
+                      size="sm"
+                      className={`w-full min-w-0 justify-start ${statusTone.fillClass} text-surface-light border ${statusTone.borderClass} rounded-full transition-colors`}
+                    >
+                      {t('Select clinic')}
+                    </Button>
+                  </DropdownTrigger>
+                  <DropdownMenu
+                    aria-label="Select destination clinic"
+                    onAction={(key) => {
+                      setShowClinicPicker(false);
+                      onStatusChange(staff, 'Transporting', key as string);
+                    }}
+                  >
+                    {clinics.map((clinic) => (
+                      <DropdownItem key={clinic.id}>{clinic.name}</DropdownItem>
+                    ))}
+                  </DropdownMenu>
+                </Dropdown>
+              ) : (
               <Select
                 aria-label="Status"
                 selectedKeys={new Set([staff.status ?? ''])}
@@ -193,19 +233,40 @@ export default function TeamCardCondensed({
                   const val = Array.from(keys as Set<string>)[0] || '';
                   if (val) {
                     if (val === 'Available') {
-                      const targetLocation = 
-                        staff.originalPost || 
-                        event.pendingAssignments?.[staff.team]?.post || 
+                      const targetLocation =
+                        staff.originalPost ||
+                        event.pendingAssignments?.[staff.team]?.post ||
                         lastValidLocation.current;
 
                       if (targetLocation && targetLocation !== staff.location) {
                         onLocationChange(staff, targetLocation);
                       } else if (staff.location === 'Clinic') {
-                        onLocationChange(staff, ''); 
+                        onLocationChange(staff, '');
                       }
                     }
-                    onStatusChange(staff, val);
+                    if (val === 'Transporting' && clinics.length > 1) {
+                      setShowClinicPicker(true);
+                      return;
+                    }
+                    onStatusChange(staff, val, val === 'Transporting' ? clinics[0]?.id : undefined);
                   }
+                }}
+                renderValue={(items) => {
+                  const key = items[0]?.key as string | undefined;
+                  if (!key) return null;
+                  if (key === 'Transporting') {
+                    const clinicName = getClinicName(clinics, activeCall?.clinicId);
+                    if (clinicName) {
+                      return (
+                        <span className="inline-flex items-center gap-1 min-w-0">
+                          <ArrowRight className="h-3.5 w-3.5 shrink-0" strokeWidth={3} />
+                          <span className="truncate">{clinicName}</span>
+                        </span>
+                      );
+                    }
+                    return t('Transporting');
+                  }
+                  return t(key);
                 }}
                 classNames={{
                   base: 'min-w-0',
@@ -216,6 +277,7 @@ export default function TeamCardCondensed({
                   <SelectItem key={s}>{t(s)}</SelectItem>
                 ))}
               </Select>
+              )}
             </div>
             
             {/* Location */}

--- a/src/components/dispatch/teamcard.tsx
+++ b/src/components/dispatch/teamcard.tsx
@@ -4,20 +4,21 @@
 import React, {useEffect, useMemo, useState, useRef} from 'react';
 import {
   Card, CardHeader, CardBody, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem,
-  Select, SelectItem, Autocomplete, AutocompleteItem
+  Select, SelectItem, Autocomplete, AutocompleteItem, Button
 } from '@heroui/react';
-import {ChevronDown, ChevronUp, MapPin, MoreVertical} from 'lucide-react';
+import {ChevronDown, ChevronUp, MapPin, MoreVertical, ArrowRight} from 'lucide-react';
 import type {Event, Staff} from '@/app/types';
 import TrackingTextEntry from '@/components/dispatch/trackingtextentry';
 import { deriveTeamVisualStatus, getStatusColor } from '@/lib/statusColors';
 import DispatchMotionCell from './motioncell';
 import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
+import { getEventClinics, getClinicName } from '@/lib/clinics';
 
 type TeamCardProps = {
   staff: Staff;
   event: Event;
   sinceMs?: number;
-  onStatusChange: (staff: Staff, newStatus: string) => void;
+  onStatusChange: (staff: Staff, newStatus: string, clinicId?: string) => void;
   onLocationChange: (staff: Staff, newLocation: string) => void;
   onEdit?: (staff: Staff) => void;
   onDelete?: (teamName: string) => void;
@@ -91,12 +92,16 @@ export default function TeamCard({
   }, [staff.members, t]);
   const timer = useMMSS(sinceMs);
 
+  const [showClinicPicker, setShowClinicPicker] = useState(false);
+  const clinics = getEventClinics(event.clinics);
+
   // Status options
-  const isOnAnyActiveCall = !!event.calls?.some(c =>
+  const activeCall = event.calls?.find(c =>
     c.assignedTeam?.includes(staff.team) && !['Resolved','Delivered','Refusal','NMM'].includes(c.status)
   );
+  const isOnAnyActiveCall = !!activeCall;
 
-  const isOnEq = !!event.calls?.some(c => 
+  const isOnEq = !!event.calls?.some(c =>
     c.equipmentTeams?.includes(staff.team) && !['Resolved','Delivered Eq','Refusal','NMM'].includes(c.status)
   ) || ['En Route Eq', 'Assisting'].includes(staff.status);
 
@@ -181,6 +186,34 @@ export default function TeamCard({
         <div className="flex items-center gap-3">
           {/* Status */}
           <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} className="min-w-0 flex-[1]">
+            {showClinicPicker ? (
+              <Dropdown
+                isOpen
+                onOpenChange={(isOpen) => {
+                  if (!isOpen) setShowClinicPicker(false);
+                }}
+              >
+                <DropdownTrigger>
+                  <Button
+                    size="sm"
+                    className={`w-full min-w-0 justify-start ${statusTone.fillClass} text-surface-light border ${statusTone.borderClass} rounded-full transition-colors`}
+                  >
+                    {t('Select clinic')}
+                  </Button>
+                </DropdownTrigger>
+                <DropdownMenu
+                  aria-label="Select destination clinic"
+                  onAction={(key) => {
+                    setShowClinicPicker(false);
+                    onStatusChange(staff, 'Transporting', key as string);
+                  }}
+                >
+                  {clinics.map((clinic) => (
+                    <DropdownItem key={clinic.id}>{clinic.name}</DropdownItem>
+                  ))}
+                </DropdownMenu>
+              </Dropdown>
+            ) : (
             <Select
               aria-label="Status"
               selectedKeys={new Set([staff.status ?? ''])}
@@ -188,19 +221,40 @@ export default function TeamCard({
                 const val = Array.from(keys as Set<string>)[0] || '';
                 if (val) {
                   if (val === 'Available') {
-                    const targetLocation = 
-                      staff.originalPost || 
-                      event.pendingAssignments?.[staff.team]?.post || 
+                    const targetLocation =
+                      staff.originalPost ||
+                      event.pendingAssignments?.[staff.team]?.post ||
                       lastValidLocation.current;
 
                     if (targetLocation && targetLocation !== staff.location) {
                       onLocationChange(staff, targetLocation);
                     } else if (staff.location === 'Clinic') {
-                      onLocationChange(staff, ''); 
+                      onLocationChange(staff, '');
                     }
                   }
-                  onStatusChange(staff, val);
+                  if (val === 'Transporting' && clinics.length > 1) {
+                    setShowClinicPicker(true);
+                    return;
+                  }
+                  onStatusChange(staff, val, val === 'Transporting' ? clinics[0]?.id : undefined);
                 }
+              }}
+              renderValue={(items) => {
+                const key = items[0]?.key as string | undefined;
+                if (!key) return null;
+                if (key === 'Transporting') {
+                  const clinicName = getClinicName(clinics, activeCall?.clinicId);
+                  if (clinicName) {
+                    return (
+                      <span className="inline-flex items-center gap-1 min-w-0">
+                        <ArrowRight className="h-3.5 w-3.5 shrink-0" strokeWidth={3} />
+                        <span className="truncate">{clinicName}</span>
+                      </span>
+                    );
+                  }
+                  return t('Transporting');
+                }
+                return t(key);
               }}
               classNames={{
                 base: 'min-w-0',
@@ -211,6 +265,7 @@ export default function TeamCard({
                 <SelectItem key={s}>{t(s)}</SelectItem>
               ))}
             </Select>
+            )}
           </div>
           {/* Location */}
           <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} className="min-w-0 flex-[1.5]">

--- a/src/components/dispatch/teamwidget.tsx
+++ b/src/components/dispatch/teamwidget.tsx
@@ -8,7 +8,7 @@ type TeamWidgetProps = {
   event: Event;
   callDisplayNumberMap: Map<string, number>;
   teamTimers: { [team: string]: number };
-  onStatusChange: (staff: Staff, newStatus: string) => void;
+  onStatusChange: (staff: Staff, newStatus: string, clinicId?: string) => void;
   onLocationChange: (staff: Staff, newLocation: string) => void;
   onEditTeam?: (staff: Staff) => void;
   onDeleteTeam?: (team: string) => void;

--- a/src/components/modals/event/venuemapmodal.tsx
+++ b/src/components/modals/event/venuemapmodal.tsx
@@ -4,7 +4,8 @@ import { createPortal } from 'react-dom';
 import Image from 'next/image';
 import { Modal, ModalContent, ModalBody, Button, Card } from '@heroui/react';
 import { ZoomIn, ZoomOut, RotateCcw, MapPin, ShieldPlus, Briefcase, HousePlus } from 'lucide-react';
-import { Post, Staff, Equipment, Layer } from '@/app/types';
+import { Post, Staff, Equipment, Layer, Call, Clinic } from '@/app/types';
+import { isClinicPost, getTransportingLabel } from '@/lib/clinics';
 
 function StatusTimer({ since }: { since: number }) {
   const [elapsed, setElapsed] = React.useState(0);
@@ -60,7 +61,7 @@ function PostMarker({ post, rect }: PostMarkerProps) {
   const top = y + (post.y / 100) * height;
   
   // Check if this is a clinic location
-  const isClinic = post.name.toLowerCase().includes('clinic');
+  const isClinic = isClinicPost(post);
   const Icon = isClinic ? HousePlus : MapPin;
   const size = isClinic ? 'h-5 w-5' : 'h-4 w-4';
   const containerSize = isClinic ? 'h-7 w-7' : 'h-6 w-6';
@@ -321,6 +322,8 @@ interface TeamMarkerProps {
   post: Post;
   rect: ImageRect;
   teamTimers: { [team: string]: number };
+  calls: Call[];
+  clinics: Clinic[];
 }
 
 function TeamMarker({
@@ -328,6 +331,8 @@ function TeamMarker({
   post,
   rect,
   teamTimers,
+  calls,
+  clinics,
 }: TeamMarkerProps) {
   const [hovered, setHovered] = useState(false);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
@@ -341,6 +346,13 @@ function TeamMarker({
   const top = rect.y + (post.y / 100) * rect.height - 16;
 
   const { color } = getTeamMarkerColors(team);
+
+  const activeCall = calls.find(c =>
+    c.assignedTeam?.includes(team.team) && !['Resolved', 'Delivered', 'Refusal', 'NMM'].includes(c.status)
+  );
+  const statusLabel = team.status === 'Transporting'
+    ? getTransportingLabel((key) => key, clinics, activeCall?.clinicId)
+    : (team.status || 'Unknown');
 
   const handleMouseEnter = () => {
     setHovered(true);
@@ -401,7 +413,7 @@ function TeamMarker({
             <div style={{ fontWeight: 'bold', fontSize: '15px', marginBottom: 4 }}>
               {team.team}
             </div>
-            <div><strong>Status:</strong> {team.status || 'Unknown'}</div>
+            <div><strong>Status:</strong> {statusLabel}</div>
             <div><strong>Post:</strong> {team.location || 'Unassigned'}</div>
             <div><strong>Status Timer:</strong> {
               typeof teamTimers[team.team] === 'number'
@@ -422,6 +434,8 @@ interface VenueMapWithPostsProps {
   staff: Staff[];
   equipment?: Equipment[];
   teamTimers: { [team: string]: number };
+  calls?: Call[];
+  clinics?: Clinic[];
   onNaturalSize?: (w: number, h: number) => void;
   isOpen?: boolean;
   scale: number;
@@ -440,6 +454,8 @@ function VenueMapWithPosts({
   staff,
   equipment = [],
   teamTimers,
+  calls = [],
+  clinics = [],
   onNaturalSize,
   isOpen,
   scale,
@@ -646,6 +662,8 @@ function VenueMapWithPosts({
                   post={postObj}
                   rect={rect}
                   teamTimers={teamTimers}
+                  calls={calls}
+                  clinics={clinics}
                 />
               );
             })}
@@ -664,6 +682,8 @@ interface VenueMapModalProps {
   staff: Staff[];
   equipment?: Equipment[];
   teamTimers: { [team: string]: number };
+  calls?: Call[];
+  clinics?: Clinic[];
 }
 
 export default function VenueMapModal({
@@ -673,6 +693,8 @@ export default function VenueMapModal({
   staff,
   equipment = [],
   teamTimers,
+  calls = [],
+  clinics = [],
 }: VenueMapModalProps) {
   const [currentLayer, setCurrentLayer] = useState(0);
   const [scale, setScale] = useState(1);
@@ -822,6 +844,8 @@ export default function VenueMapModal({
                 staff={staff}
                 equipment={equipment}
                 teamTimers={teamTimers}
+                calls={calls}
+                clinics={clinics}
                 isOpen={isOpen}
                 scale={scale}
                 position={position}

--- a/src/lib/clinics.ts
+++ b/src/lib/clinics.ts
@@ -1,0 +1,121 @@
+import type { Clinic, Post, Venue } from '@/app/types';
+
+export const DEFAULT_CLINICS: Clinic[] = [{ id: 'clinic', name: 'Clinic' }];
+
+/** Resolves an event's clinics, falling back to a single default "Clinic" for events/venues with no clinic-flagged posts. */
+export function getEventClinics(clinics: Clinic[] | undefined): Clinic[] {
+  return clinics && clinics.length > 0 ? clinics : DEFAULT_CLINICS;
+}
+
+type ClinicPost = Extract<Post, object> & { isClinic: true };
+
+export function isClinicPost(post: Post): post is ClinicPost {
+  return typeof post === 'object' && post !== null && post.isClinic === true;
+}
+
+/** Minimal shape accepted by getVenuePosts — matches both Venue and LiteVenueSetup. */
+type PostsSource = { posts?: Post[]; layers?: { posts: Post[] }[] };
+
+/**
+ * Flattens a venue's posts, preferring the flattened `venue.posts` cache
+ * (written by venue-management on save) and falling back to layer posts
+ * for venues that haven't been re-saved since layers were introduced.
+ */
+export function getVenuePosts(venue: PostsSource | Venue | undefined | null): Post[] {
+  if (!venue) return [];
+  if (venue.posts && venue.posts.length > 0) return venue.posts;
+  return (venue.layers || []).flatMap(layer => layer.posts || []);
+}
+
+/**
+ * Additively merges clinic-flagged venue posts into an event's existing
+ * clinics list, matched by the post's stable `clinicId`. Never removes an
+ * entry whose backing post disappeared, so existing calls' `clinicId`
+ * references are never orphaned.
+ */
+export function syncClinicsFromVenue(
+  venue: PostsSource | Venue | undefined | null,
+  existingClinics: Clinic[] | undefined
+): Clinic[] {
+  const clinicPosts = getVenuePosts(venue).filter(isClinicPost).filter(p => !!p.clinicId);
+
+  const byId = new Map((existingClinics || []).map(c => [c.id, c]));
+
+  for (const post of clinicPosts) {
+    const id = post.clinicId!;
+    const existing = byId.get(id);
+    if (!existing) {
+      byId.set(id, { id, name: post.name });
+    } else if (existing.name !== post.name) {
+      byId.set(id, { ...existing, name: post.name });
+    }
+  }
+
+  return Array.from(byId.values());
+}
+
+/**
+ * True if `name` matches another clinic-flagged post in `allPosts`
+ * (case-insensitive), excluding the post currently being edited. Two
+ * clinics sharing a name would render two identically-labeled dispatch
+ * tabs, so this is scoped to clinic-flagged posts only — regular posts
+ * may still share names.
+ */
+export function hasDuplicateClinicName(
+  name: string,
+  allPosts: { post: Post; layerIdx: number; postIdx: number }[],
+  exclude?: { layerIdx: number; postIdx: number }
+): boolean {
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) return false;
+  return allPosts.some(({ post, layerIdx, postIdx }) => {
+    if (exclude && layerIdx === exclude.layerIdx && postIdx === exclude.postIdx) return false;
+    if (!isClinicPost(post)) return false;
+    return post.name.trim().toLowerCase() === trimmed;
+  });
+}
+
+/**
+ * Resolves a clinic's display name by id, but only when more than one
+ * clinic exists — single-clinic events have nothing worth naming.
+ */
+export function getClinicName(clinics: Clinic[], clinicId: string | undefined): string | undefined {
+  if (clinics.length <= 1) return undefined;
+  return clinics.find(c => c.id === clinicId)?.name;
+}
+
+function withClinicDestination(
+  t: (key: string) => string,
+  label: string,
+  clinics: Clinic[],
+  clinicId: string | undefined
+): string {
+  const clinicName = getClinicName(clinics, clinicId);
+  return clinicName ? `${label} ${t('to')} ${clinicName}` : label;
+}
+
+/**
+ * Status pill label for a team that's Transporting. Only decorates with a
+ * destination when more than one clinic exists and the clinicId resolves —
+ * single-clinic events keep the plain "Transporting" label. The resolved
+ * clinic name is user-authored text and is never passed through `t()`.
+ */
+export function getTransportingLabel(
+  t: (key: string) => string,
+  clinics: Clinic[],
+  clinicId: string | undefined
+): string {
+  return withClinicDestination(t, t('Transporting'), clinics, clinicId);
+}
+
+/**
+ * Status pill label for a team/call resolved as Delivered. Same destination
+ * decoration rules as getTransportingLabel.
+ */
+export function getDeliveredLabel(
+  t: (key: string) => string,
+  clinics: Clinic[],
+  clinicId: string | undefined
+): string {
+  return withClinicDestination(t, t('Delivered'), clinics, clinicId);
+}

--- a/src/lib/liteEventAdapters.ts
+++ b/src/lib/liteEventAdapters.ts
@@ -49,6 +49,7 @@ export function normalizeLiteDraftToEvent(draft: LiteEventDraft): Event {
     postAssignments: draft.postAssignments || {},
     pendingAssignments: draft.pendingAssignments || {},
     surgeLimitPercent: draft.surgeLimitPercent,
+    clinics: draft.clinics || [],
   };
 }
 
@@ -74,6 +75,7 @@ export function toLiteDraftFromEvent(nextEvent: Event, previousDraft: LiteEventD
     postAssignments: nextEvent.postAssignments || {},
     pendingAssignments: nextEvent.pendingAssignments || {},
     surgeLimitPercent: nextEvent.surgeLimitPercent ?? previousDraft.surgeLimitPercent,
+    clinics: nextEvent.clinics ?? previousDraft.clinics,
     createdAt:
       typeof nextEvent.createdAt === 'string' ? nextEvent.createdAt : previousDraft.createdAt,
     updatedAt: new Date().toISOString(),

--- a/src/lib/liteEventStore.ts
+++ b/src/lib/liteEventStore.ts
@@ -2,6 +2,7 @@
 
 import type {
   Call,
+  Clinic,
   Equipment,
   EventEquipment,
   PostAssignment,
@@ -49,6 +50,7 @@ export interface LiteEventDraft {
   };
   eventEquipment: EventEquipment[];
   calls: Call[];
+  clinics?: Clinic[];
   status: 'draft' | 'active';
   createdAt: string;
   updatedAt: string;

--- a/tests/e2e/pb_migrations/1783563670_created_events.js
+++ b/tests/e2e/pb_migrations/1783563670_created_events.js
@@ -183,6 +183,16 @@ migrate((app) => {
         "required": false,
         "system": false,
         "type": "json"
+      },
+      {
+        "hidden": false,
+        "id": "json2091837456",
+        "maxSize": 0,
+        "name": "clinics",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "json"
       }
     ],
     "id": "pbc_1687431684",


### PR DESCRIPTION
## Summary

Completes multi-clinic dispatch support (fixes #23). A prior pass laid partial groundwork — `Post.isClinic`, `Clinic{id,name}`, `Event.clinics`, `Call.clinicId`, and full per-clinic tab rendering already existed — but two things were actually broken:

1. `Event.clinics` was never written anywhere, and didn't exist in the PocketBase schema at all, so it silently dropped on PocketBase-backed deployments.
2. Every call defaulted to `clinics[0]` — there was no way for staff to choose a destination clinic, and the map builder's clinic icon was inconsistent across three render sites (one used a `.includes('clinic')` name-string heuristic instead of the real flag).

## Changes

- **Schema + sync** (`src/lib/clinics.ts`, `scripts/setup-pocketbase.js`, `tests/e2e/pb_migrations/…created_events.js`): `events.clinics` is now a real, schema-backed `json` field. `Post` gained a stable `clinicId`, generated once when a post is first marked as a clinic and preserved through renames. `syncClinicsFromVenue` additively merges venue clinic-posts into an event's clinics (add new, rename in place, never delete — so existing calls' `clinicId` references never orphan), wired in at event creation and as a lazy write-through on dispatch load.
- **Map builder icon consistency**: the builder canvas, the builder's location list, and the dispatch-side venue map modal all now show a consistent clinic icon (`HousePlus`) driven by the real `isClinic` flag, plus a duplicate-clinic-name guard.
- **Destination picker**: marking a team "Transporting" on a multi-clinic event now prompts for which clinic they're headed to (both the calls-table chip and the sidebar team-status dropdown); single-clinic events are unaffected — no prompt, same as before. Fixed a real bug along the way where the sidebar status-change path never wrote `clinicId` onto the call at all.
- **Status pills, chips, and logs** reflect the destination clinic: "Transporting to {clinic}" / "Delivered to {clinic}" in the calls table and call chips, a compact arrow-icon + clinic name in the team card's status pill, and the call activity log now records the destination on both the Transporting and Delivered transitions.
- **Venue map tooltip**: the dispatch board's live map now shows the same destination-aware status for team markers.

## Test plan

- [x] `tsc --noEmit` and `eslint src/` clean across the whole repo (no new errors, only pre-existing warnings)
- [x] Manually verified on a 2-clinic event: two clinic tabs render, clinic icons consistent everywhere, Transporting prompts for a clinic from both entry points, pills/chips/logs show the right destination, single-clinic events are unaffected
- [x] Checked existing `dispatch.feature` / `clinic-operations.feature` scenarios against their step definitions — all new branching is gated behind `clinics.length > 1` and no existing fixture marks a post as a clinic, so the existing single-clinic e2e scenarios exercise the unchanged code path
- [ ] CI (Firebase + PocketBase e2e suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)