### PR TITLE
Reversible call resolution and transport unit capture

### DIFF
--- a/src/app/(main)/events/[eventId]/dispatch/page.tsx
+++ b/src/app/(main)/events/[eventId]/dispatch/page.tsx
@@ -7,6 +7,7 @@ import QuickCallModal from "@/components/modals/event/quickcallmodal";
 import ClinicWalkupModal from "@/components/dispatch/clinicwalkupmodal";
 import AddTeamModal from "@/components/modals/event/addteammodal";
 import AddSupervisorModal from "@/components/modals/event/addsupervisormodal";
+import TransportUnitModal from "@/components/modals/event/transportunitmodal";
 import React from 'react';
 import { dbService, ServiceError } from '@/lib/services';
 import { PostAssignment, Event, Staff, Supervisor, Call, EquipmentStatus, CallLogEntry, TeamLogEntry, EquipmentItem, EventEquipment, ClinicOutcome, Clinic } from '@/app/types';
@@ -150,6 +151,10 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
   const [editSupervisorOriginalName, setEditSupervisorOriginalName] = useState<string | null>(null);
   const [showQuickClinicCallForm, setShowQuickClinicCallForm] = useState(false);
   const [showDebugModal, setShowDebugModal] = useState(false);
+
+  const [showTransportUnitModal, setShowTransportUnitModal] = useState(false);
+  const [transportUnitCallId, setTransportUnitCallId] = useState<string | null>(null);
+  const [transportUnitValue, setTransportUnitValue] = useState('');
   
   // Configure admin emails here or load from environment / Firestore for your deployment.
   const ADMIN_EMAILS: string[] = [];
@@ -1144,7 +1149,11 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
     let newCallStatus = latestCall.status; // Initialize with current status
     
     const isEqDetaching = ['Delivered Eq'].includes(newStatus);
-    
+    // Status the team held immediately before this change, captured here (before teamStatusMap
+    // is overwritten above) so a later revert can restore it.
+    const priorTeamStatus = teamStatusMap[callId]?.[team];
+    const priorTeamLocation = event?.staff.find(s => s.team === team)?.location;
+
     const updatedCalls = (event?.calls || []).map(c => {
       console.log('call updated');
       if (c.id !== callId) return c;
@@ -1164,9 +1173,16 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
         
         // Record detachment
         if (!updatedDetachedTeams.some(t => t.team === team)) {
-          updatedDetachedTeams.push({ 
-            team, 
-            reason: newStatus === 'Delivered Eq' ? 'Delivered Eq' : 'Detached' 
+          const equipmentNames = (event?.eventEquipment || [])
+            .filter(eq => eq.assignedTeam === team)
+            .map(eq => eq.name);
+          updatedDetachedTeams.push({
+            team,
+            reason: newStatus === 'Delivered Eq' ? 'Delivered Eq' : 'Detached',
+            kind: 'equipment',
+            previousStatus: priorTeamStatus || 'En Route Eq',
+            previousLocation: priorTeamLocation,
+            equipmentNames,
           });
         }
       } else if (isDetaching) {
@@ -1178,18 +1194,30 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
 
         // record one-time detachment
         if (!updatedDetachedTeams.some(t => t.team === team)) {
-          updatedDetachedTeams.push({ team, reason: newStatus });
+          updatedDetachedTeams.push({
+            team,
+            reason: newStatus,
+            kind: 'team',
+            previousStatus: priorTeamStatus || 'En Route',
+            previousLocation: priorTeamLocation,
+          });
         }
 
         // Auto-detach supervisors when any team is detached with resolving status
         if (['Delivered', 'Refusal', 'NMM'].includes(newStatus)) {
-          const supervisorsOnCall = event?.supervisor?.filter(s => 
+          const supervisorsOnCall = event?.supervisor?.filter(s =>
             c.assignedTeam?.includes(s.team)
           ) || [];
-          
+
           supervisorsOnCall.forEach(supervisor => {
             if (!updatedDetachedTeams.some(t => t.team === supervisor.team)) {
-              updatedDetachedTeams.push({ team: supervisor.team, reason: 'Auto-detached' });
+              updatedDetachedTeams.push({
+                team: supervisor.team,
+                reason: 'Auto-detached',
+                kind: 'supervisor',
+                previousStatus: supervisor.status,
+                previousLocation: supervisor.location,
+              });
             }
           });
           
@@ -1419,6 +1447,203 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
       ...(updatedEquipment && { eventEquipment: updatedEquipment })
     });
   };
+
+  // Reverses a single detached-team entry (regular team, equipment run, or auto-detached
+  // supervisor): restores its prior status/location, re-attaches it to the call, and — for a
+  // regular team — recomputes the call's composite status and clears clinic membership if
+  // nothing else on the call is still Delivered.
+  const handleRevertDetachment = (callId: string, team: string) => {
+    const call = event?.calls.find(c => c.id === callId);
+    if (!call) return;
+    const detachedEntry = call.detachedTeams?.find(d => d.team === team);
+    if (!detachedEntry) return;
+
+    const kind = detachedEntry.kind || 'team';
+    const confirmMessage =
+      kind === 'equipment' ? t('Revert this equipment status and reattach it to the team?')
+      : kind === 'supervisor' ? t('Revert this supervisor detachment and reattach them to the call?')
+      : t('Revert this status and reopen the call?');
+
+    if (!confirm(confirmMessage)) return;
+
+    const restoredStatus = detachedEntry.previousStatus || (kind === 'equipment' ? 'En Route Eq' : 'En Route');
+    const now = new Date();
+    const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
+    const logMessage = `${hhmm} - ${team} status reverted, ${kind === 'supervisor' ? 'supervisor reattached' : kind === 'equipment' ? 'equipment run reattached' : 'call reopened'}`;
+
+    setTeamStatusMap(prev => ({
+      ...prev,
+      [callId]: {
+        ...(prev[callId] || {}),
+        [team]: restoredStatus
+      }
+    }));
+
+    const updatedCalls = (event?.calls || []).map(c => {
+      if (c.id !== callId) return c;
+
+      const remainingDetached = (c.detachedTeams || []).filter(d => d.team !== team);
+      const updatedLog = [...(c.log || []), { timestamp: now.getTime(), message: logMessage }];
+
+      let updatedAssignedTeam = c.assignedTeam || [];
+      let updatedEquipmentTeams = c.equipmentTeams || [];
+
+      if (!updatedAssignedTeam.includes(team)) {
+        updatedAssignedTeam = [...updatedAssignedTeam, team];
+      }
+      if (kind === 'equipment' && !updatedEquipmentTeams.includes(team)) {
+        updatedEquipmentTeams = [...updatedEquipmentTeams, team];
+      }
+
+      let newCallStatus = c.status;
+      let clinicFlag = c.clinic;
+      let clinicId = c.clinicId;
+      let outcome = c.outcome;
+
+      if (kind === 'team') {
+        if (restoredStatus === 'Transporting') newCallStatus = 'Transporting';
+        else if (restoredStatus === 'On Scene') newCallStatus = 'On Scene';
+        else newCallStatus = 'En Route';
+
+        // If no other detached team on this call is still Delivered, the call is no longer
+        // clinic-bound.
+        const stillDelivered = remainingDetached.some(d => d.reason === 'Delivered');
+        if (!stillDelivered) {
+          clinicFlag = false;
+          clinicId = undefined;
+          outcome = undefined;
+        }
+      }
+
+      return {
+        ...c,
+        status: newCallStatus,
+        clinic: clinicFlag,
+        clinicId,
+        outcome,
+        log: updatedLog,
+        assignedTeam: updatedAssignedTeam,
+        equipmentTeams: updatedEquipmentTeams,
+        detachedTeams: remainingDetached,
+      };
+    });
+
+    let updatedStaff = event?.staff;
+    let updatedSupervisor = event?.supervisor;
+
+    if (kind === 'supervisor') {
+      updatedSupervisor = event?.supervisor?.map(s =>
+        s.team === team
+          ? {
+              ...s,
+              status: restoredStatus,
+              location: detachedEntry.previousLocation || s.location,
+              log: [...(s.log || []), { timestamp: now.getTime(), message: logMessage }],
+            }
+          : s
+      );
+    } else {
+      updatedStaff = event?.staff.map(t =>
+        t.team === team
+          ? {
+              ...t,
+              status: restoredStatus,
+              location: detachedEntry.previousLocation || call.location,
+            }
+          : t
+      );
+    }
+
+    let updatedEquipment = event?.eventEquipment;
+    if (kind === 'equipment' && detachedEntry.equipmentNames?.length) {
+      updatedEquipment = event?.eventEquipment?.map(eq =>
+        detachedEntry.equipmentNames?.includes(eq.name)
+          ? { ...eq, assignedTeam: team, status: 'In Use' as EquipmentStatus, location: call.location }
+          : eq
+      );
+    }
+
+    updateEvent({
+      calls: updatedCalls,
+      ...(updatedStaff && { staff: updatedStaff }),
+      ...(updatedSupervisor && { supervisor: updatedSupervisor }),
+      ...(updatedEquipment && { eventEquipment: updatedEquipment }),
+    });
+  };
+
+  // Shared clinic-outcome change handler used by both ClinicTrackingTable and
+  // ClinicTrackingCard. Selecting 'Transported' doesn't commit immediately — it opens
+  // TransportUnitModal to capture the ambulance/transport unit number first.
+  const handleClinicOutcomeChange = useCallback((callId: string, outcome: string) => {
+    if (outcome === 'Transported') {
+      setTransportUnitCallId(callId);
+      setTransportUnitValue('');
+      setShowTransportUnitModal(true);
+      return;
+    }
+
+    updateEvent((current) => {
+      const callToUpdate = current.calls.find(c => c.id === callId);
+      if (!callToUpdate) return {};
+
+      const now = new Date();
+      const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
+      const updatedCall = {
+        ...callToUpdate,
+        outcome: outcome === 'In Clinic' ? undefined : outcome as ClinicOutcome,
+        transportUnit: outcome === 'In Clinic' ? undefined : callToUpdate.transportUnit,
+        log: [...(callToUpdate.log || []), { timestamp: now.getTime(), message: `${hhmm} - Clinic Status: ${outcome}` }]
+      };
+      return { calls: current.calls.map(c => c.id === callId ? updatedCall : c) };
+    });
+  }, [updateEvent]);
+
+  const handleSubmitTransportUnit = useCallback(async () => {
+    if (!transportUnitCallId) return;
+    const callId = transportUnitCallId;
+    const unit = transportUnitValue.trim();
+
+    await updateEvent((current) => {
+      const callToUpdate = current.calls.find(c => c.id === callId);
+      if (!callToUpdate) return {};
+
+      const now = new Date();
+      const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
+      const updatedCall = {
+        ...callToUpdate,
+        outcome: 'Transported' as ClinicOutcome,
+        transportUnit: unit || undefined,
+        log: [
+          ...(callToUpdate.log || []),
+          { timestamp: now.getTime(), message: unit ? `${hhmm} - Transported by ${unit}` : `${hhmm} - Clinic Status: Transported` }
+        ]
+      };
+      return { calls: current.calls.map(c => c.id === callId ? updatedCall : c) };
+    });
+
+    setShowTransportUnitModal(false);
+    setTransportUnitCallId(null);
+    setTransportUnitValue('');
+  }, [transportUnitCallId, transportUnitValue, updateEvent]);
+
+  const handleRevertClinicOutcome = useCallback(async (callId: string) => {
+    if (!confirm(t('Revert this clinic outcome?'))) return;
+
+    await updateEvent((current) => {
+      const callToUpdate = current.calls.find(c => c.id === callId);
+      if (!callToUpdate) return {};
+
+      const now = new Date();
+      const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
+      const updatedCall = {
+        ...callToUpdate,
+        outcome: undefined,
+        transportUnit: undefined,
+        log: [...(callToUpdate.log || []), { timestamp: now.getTime(), message: `${hhmm} - Clinic outcome reverted to In Clinic` }]
+      };
+      return { calls: current.calls.map(c => c.id === callId ? updatedCall : c) };
+    });
+  }, [updateEvent, t]);
 
   const [showResolvedCalls, setShowResolvedCalls] = useState(false);
 
@@ -3038,6 +3263,17 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
         parseAgeSex={parseAgeSex}
         clinicId={clinics.find(c => c.id === selectedRightTab)?.id || clinics[0]?.id}
       />
+      <TransportUnitModal
+        isOpen={showTransportUnitModal}
+        onClose={() => {
+          setShowTransportUnitModal(false);
+          setTransportUnitCallId(null);
+          setTransportUnitValue('');
+        }}
+        onSubmit={handleSubmitTransportUnit}
+        value={transportUnitValue}
+        onValueChange={setTransportUnitValue}
+      />
       <AddTeamModal
         isOpen={showAddTeamModal}
         onClose={() => setShowAddTeamModal(false)}
@@ -3363,6 +3599,7 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
                           handleTeamStatusChange={handleTeamStatusChange}
                           handleRemoveTeamFromCall={handleRemoveTeamFromCall}
                           handleAddTeamToCall={handleAddTeamToCall}
+                          handleRevertDetachment={handleRevertDetachment}
                           getCallRowClass={getCallRowClass}
                           formatAgeSex={formatAgeSex}
                           TableColGroup={TableColGroup}
@@ -3406,6 +3643,8 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
                           handleCellClick={handleCellClick}
                           handleCellBlur={handleCellBlur}
                           handleAgeSexBlur={handleAgeSexBlur}
+                          onOutcomeChange={handleClinicOutcomeChange}
+                          onRevertOutcome={handleRevertClinicOutcome}
                           getCallRowClass={getCallRowClass}
                           formatAgeSex={formatAgeSex}
                         />
@@ -3652,6 +3891,7 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
                           onRemoveTeamFromCall={handleRemoveTeamFromCall}
                           onAddTeamToCall={handleAddTeamToCall}
                           handleTeamStatusChange={handleTeamStatusChange}
+                          handleRevertDetachment={handleRevertDetachment}
                           handleMarkDuplicate={handleMarkDuplicate}
                           handleTogglePriority={handleTogglePriorityFromMenu}
                           handleDeleteCall={handleDeleteCall}
@@ -3748,20 +3988,8 @@ export default function DispatchPage({ params }: DispatchRoutePageProps) {
                             const updatedCalls = event.calls.map(c => c.id === callId ? updatedCall : c);
                             await updateEvent({ calls: updatedCalls });
                           }}
-                          onOutcomeChange={async (callId, outcome) => {
-                            const callToUpdate = event.calls.find(c => c.id === callId);
-                            if (!callToUpdate) return;
-                            
-                            const now = new Date();
-                            const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
-                            const updatedCall = {
-                              ...callToUpdate,
-                              outcome: outcome === 'In Clinic' ? undefined : outcome as ClinicOutcome,
-                              log: [...(callToUpdate.log || []), { timestamp: now.getTime(), message: `${hhmm} - Clinic Status: ${outcome}` }]
-                            };
-                            const updatedCalls = event.calls.map(c => c.id === callId ? updatedCall : c);
-                            await updateEvent({ calls: updatedCalls });
-                          }}
+                          onOutcomeChange={handleClinicOutcomeChange}
+                          onRevertOutcome={handleRevertClinicOutcome}
                           handleDeleteCall={handleDeleteCall}
                           getCallRowClass={getCallRowClass}
                           formatAgeSex={formatAgeSex}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -103,9 +103,17 @@ export interface CallLogEntry {
   message: string;
 }
 
-interface DetachedTeam {
+export interface DetachedTeam {
   team: string;
   reason: string;
+  /** What kind of assignment this was, so a revert knows how to restore it. Defaults to 'team' when absent (legacy data). */
+  kind?: 'team' | 'supervisor' | 'equipment';
+  /** Status the team/supervisor held immediately before this detachment, used to revert. */
+  previousStatus?: string;
+  /** Location the team/supervisor held immediately before this detachment, used to revert. */
+  previousLocation?: string;
+  /** Names of equipment items that moved off this team at detach time (kind === 'equipment' only), used to revert. */
+  equipmentNames?: string[];
 }
 
 export type ClinicOutcome = "Discharged" | "AMA" | "Rolled from Clinic" | "Transported";
@@ -131,6 +139,8 @@ export interface Call {
   clinic?: boolean;
   clinicId?: string;
   outcome?: ClinicOutcome;
+  /** Ambulance/transport unit number captured when outcome is set to 'Transported'. */
+  transportUnit?: string;
 }
 
 export interface CallLogEntry {

--- a/src/components/dispatch/calltracking.tsx
+++ b/src/components/dispatch/calltracking.tsx
@@ -10,8 +10,8 @@ import {
   DropdownMenu, 
   DropdownItem,
 } from '@heroui/react';
-import { Plus, MoreVertical } from "lucide-react";
-import type { Event, Call, EquipmentStatus, Supervisor, Staff, Equipment } from '@/app/types';
+import { Plus, MoreVertical, RotateCw } from "lucide-react";
+import type { Event, Call, EquipmentStatus, Supervisor, Staff, Equipment, DetachedTeam } from '@/app/types';
 import { useCallTrackingState } from '@/hooks/useCallTrackingState';
 import CallTrackingDetails from '@/components/dispatch/calltrackingdetails';
 import DispatchMotionCell from './motioncell';
@@ -56,14 +56,10 @@ interface CallTrackingTableProps {
   handleTeamStatusChange: (callId: string, team: string, newStatus: string, clinicId?: string) => void;
   handleRemoveTeamFromCall: (callId: string, team: string) => Promise<void>;
   handleAddTeamToCall: (callId: string, team: string) => Promise<void>;
+  handleRevertDetachment: (callId: string, team: string) => void;
   getCallRowClass: (call: Call) => string;
   formatAgeSex: (age?: string | number, gender?: string) => string;
   TableColGroup: React.ComponentType;
-}
-
-interface DetachedTeam {
-  team: string;
-  reason: string;
 }
 
 interface LogEntry {
@@ -103,6 +99,7 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
   handleTeamStatusChange,
   handleRemoveTeamFromCall,
   handleAddTeamToCall,
+  handleRevertDetachment,
   getCallRowClass,
   formatAgeSex,
   TableColGroup,
@@ -500,6 +497,8 @@ export const CallTrackingTable: React.FC<CallTrackingTableProps> = ({
                                 variant="flat"
                                 color={detachedTeam.reason === 'Delivered' ? 'success' : 'default'}
                                 className="border border-surface-liner h-8"
+                                onClose={() => handleRevertDetachment(call.id, detachedTeam.team)}
+                                endContent={<RotateCw className="w-3.5 h-3.5" aria-label={t('Reopen Call')} />}
                               >
                                 <span className="text-surface-light font-medium mr-2">
                                   {detachedTeam.team}

--- a/src/components/dispatch/calltrackingcard.tsx
+++ b/src/components/dispatch/calltrackingcard.tsx
@@ -6,7 +6,7 @@ import {
   Card, CardHeader, CardBody, Input, Chip, Button,
   Dropdown, DropdownTrigger, DropdownMenu, DropdownItem
 } from '@heroui/react';
-import { Plus, MoreVertical } from 'lucide-react';
+import { Plus, MoreVertical, RotateCw } from 'lucide-react';
 import {
   Dropdownmenu,
   DropdownMenuContent,
@@ -16,7 +16,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import type { Event, Call } from '@/app/types';
+import type { Event, Call, DetachedTeam } from '@/app/types';
 import TrackingTextEntry from '@/components/dispatch/trackingtextentry';
 import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
 import { getEventClinics, getTransportingLabel, getDeliveredLabel } from '@/lib/clinics';
@@ -31,6 +31,7 @@ type CallTrackingCardProps = {
   onRemoveTeamFromCall: (callId: string, team: string) => Promise<void>;
   onAddTeamToCall: (callId: string, team: string) => Promise<void>;
   handleTeamStatusChange: (callId: string, team: string, newStatus: string, clinicId?: string) => void;
+  handleRevertDetachment: (callId: string, team: string) => void;
   handleMarkDuplicate: (callId: string) => void;
   handleTogglePriority: (callId: string) => void;
   handleDeleteCall: (callId: string) => void;
@@ -85,6 +86,7 @@ export default function CallTrackingCard({
   onRemoveTeamFromCall,
   onAddTeamToCall,
   handleTeamStatusChange,
+  handleRevertDetachment,
   handleMarkDuplicate,
   handleTogglePriority,
   handleDeleteCall,
@@ -408,13 +410,15 @@ export default function CallTrackingCard({
           })}
 
           {/* Detached teams */}
-          {call.detachedTeams?.map((detachedTeam: { team: string; reason: string }) => (
+          {call.detachedTeams?.map((detachedTeam: DetachedTeam) => (
             <Chip
               key={detachedTeam.team}
               size="lg"
               variant="flat"
               color={detachedTeam.reason === 'Delivered' ? 'success' : 'default'}
               className="border border-surface-liner h-9"
+              onClose={() => handleRevertDetachment(call.id, detachedTeam.team)}
+              endContent={<RotateCw className="w-3.5 h-3.5" aria-label={t('Reopen Call')} />}
             >
               <span className="text-surface-light font-medium mr-2">
                 {detachedTeam.team}

--- a/src/components/dispatch/clinictracking.tsx
+++ b/src/components/dispatch/clinictracking.tsx
@@ -9,8 +9,8 @@ import {
   DropdownMenu, 
   DropdownItem
 } from '@heroui/react';
-import { MoreVertical } from 'lucide-react';
-import type { Event, Call, CallLogEntry, ClinicOutcome, Clinic } from '@/app/types';
+import { MoreVertical, RotateCw } from 'lucide-react';
+import type { Event, Call, CallLogEntry, Clinic } from '@/app/types';
 import DispatchMotionCell from './motioncell';
 import TrackingTableBase from './trackingtablebase';
 import { TEAM_CARD_ROW_HOVER_CLASS } from '@/lib/statusColors';
@@ -36,6 +36,8 @@ interface ClinicTrackingTableProps {
   handleCellClick: <K extends keyof Call>(callId: string, field: K, value?: Call[K]) => void;
   handleCellBlur: <K extends keyof Call>(callId: string, field: K) => Promise<void>;
   handleAgeSexBlur: (callId: string) => Promise<void>;
+  onOutcomeChange: (callId: string, outcome: string) => void;
+  onRevertOutcome: (callId: string) => void;
   getCallRowClass: (call: Call) => string;
   formatAgeSex: (age?: string | number, gender?: string) => string;
 }
@@ -55,7 +57,7 @@ const TableColGroup = () => (
     <col className="w-40" />
     <col className="w-16" />
     <col className="w-48" />
-    <col className="w-28" />
+    <col className="w-40" />
     <col />
     <col className="w-12" />
   </colgroup>
@@ -78,6 +80,8 @@ export default function ClinicTrackingTable({
   handleCellClick,
   handleCellBlur,
   handleAgeSexBlur,
+  onOutcomeChange,
+  onRevertOutcome,
   getCallRowClass,
   formatAgeSex,
 }: ClinicTrackingTableProps) {
@@ -349,59 +353,52 @@ export default function ClinicTrackingTable({
                   {/* Status - Using HeroUI Dropdown */}
                   <td className="p-0" onClick={e => e.stopPropagation()}>
                     <DispatchMotionCell isOpen={isClinicCallVisible(call)} animate={isResolvedClinicCall} delayMs={motionDelayMs} className="px-3 py-2.5">
-                      <Dropdown
-                        motionProps={dropdownMotionProps}
-                        isOpen={isStatusMenuOpen}
-                        onOpenChange={(isOpen) => {
-                          if (isOpen) {
-                            if (isResolvedClinicCall && !showResolvedClinicCalls) return;
-                            setOpenMenuToken(`status:${call.id}`);
-                            return;
-                          }
-                          setOpenMenuToken((current) => (current === `status:${call.id}` ? null : current));
-                        }}
-                      >
-                        <DropdownTrigger>
-                          <Button
-                            size="sm"
-                            variant="flat"
-                            className="min-w-0 h-8 px-2 text-xs justify-start bg-surface-liner hover:bg-surface-muted"
-                          >
-                            {t(call.outcome || 'In Clinic')}
-                          </Button>
-                        </DropdownTrigger>
-                        <DropdownMenu
-                          aria-label="Clinic Status"
-                          onAction={async (key) => {
-                            setOpenMenuToken(null);
-                            const val = key as string;
-                            const now = new Date();
-                            const hhmm = now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0');
-
-                            const updatedCalls = event.calls.map((c: Call) => {
-                              if (c.id !== call.id) return c;
-                              return {
-                                ...c,
-                                outcome: val === 'In Clinic' ? undefined : val as ClinicOutcome,
-                                log: [
-                                  ...(c.log || []),
-                                  {
-                                    timestamp: now.getTime(),
-                                    message: `${hhmm} - Clinic Status: ${val}`
-                                  }
-                                ]
-                              } as Call;
-                            });
-
-                            await updateEvent({ calls: updatedCalls });
+                      <div className={`flex items-center h-8 w-fit max-w-full rounded-full border border-surface-liner bg-surface-liner/30 overflow-hidden ${call.outcome ? 'pr-1.5' : ''}`}>
+                        <Dropdown
+                          motionProps={dropdownMotionProps}
+                          isOpen={isStatusMenuOpen}
+                          onOpenChange={(isOpen) => {
+                            if (isOpen) {
+                              if (isResolvedClinicCall && !showResolvedClinicCalls) return;
+                              setOpenMenuToken(`status:${call.id}`);
+                              return;
+                            }
+                            setOpenMenuToken((current) => (current === `status:${call.id}` ? null : current));
                           }}
                         >
-                          <DropdownItem key="In Clinic">{t('In Clinic')}</DropdownItem>
-                          <DropdownItem key="Transported">{t('Transported')}</DropdownItem>
-                          <DropdownItem key="AMA">{t('AMA')}</DropdownItem>
-                          <DropdownItem key="Discharged">{t('Discharged')}</DropdownItem>
-                        </DropdownMenu>
-                      </Dropdown>
+                          <DropdownTrigger>
+                            <Button
+                              size="sm"
+                              variant="light"
+                              className="min-w-0 h-8 px-2 text-xs justify-start bg-transparent hover:bg-surface-muted"
+                            >
+                              {t(call.outcome || 'In Clinic')}
+                            </Button>
+                          </DropdownTrigger>
+                          <DropdownMenu
+                            aria-label="Clinic Status"
+                            onAction={(key) => {
+                              setOpenMenuToken(null);
+                              onOutcomeChange(call.id, key as string);
+                            }}
+                          >
+                            <DropdownItem key="In Clinic">{t('In Clinic')}</DropdownItem>
+                            <DropdownItem key="Transported">{t('Transported')}</DropdownItem>
+                            <DropdownItem key="AMA">{t('AMA')}</DropdownItem>
+                            <DropdownItem key="Discharged">{t('Discharged')}</DropdownItem>
+                          </DropdownMenu>
+                        </Dropdown>
+                        {call.outcome && (
+                          <button
+                            type="button"
+                            onClick={() => onRevertOutcome(call.id)}
+                            className="p-0 m-0 border-0 bg-transparent text-surface-light hover:text-status-blue transition-colors cursor-pointer flex items-center justify-center shrink-0"
+                            aria-label={t('Reopen Call')}
+                          >
+                            <RotateCw className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                      </div>
                     </DispatchMotionCell>
                   </td>
 

--- a/src/components/dispatch/clinictrackingcard.tsx
+++ b/src/components/dispatch/clinictrackingcard.tsx
@@ -6,7 +6,7 @@ import {
   Card, CardHeader, CardBody, Input, Button,
   Dropdown, DropdownTrigger, DropdownMenu, DropdownItem
 } from '@heroui/react';
-import { MoreVertical } from 'lucide-react';
+import { MoreVertical, RotateCw } from 'lucide-react';
 import type { Event, Call } from '@/app/types';
 import TrackingTextEntry from '@/components/dispatch/trackingtextentry';
 import { useDispatchTerms } from '@/lib/dispatchVocabulary/context';
@@ -19,6 +19,7 @@ type ClinicTrackingCardProps = {
   onAgeSexChange: (callId: string, ageSex: string) => void;
   onChiefComplaintChange: (callId: string, chiefComplaint: string) => void;
   onOutcomeChange: (callId: string, outcome: string) => void;
+  onRevertOutcome: (callId: string) => void;
   handleDeleteCall: (callId: string) => void;
   formatAgeSex: (age?: string | number, gender?: string) => string;
   getCallRowClass: (call: Call) => string;
@@ -58,6 +59,7 @@ export default function ClinicTrackingCard({
   onAgeSexChange,
   onChiefComplaintChange,
   onOutcomeChange,
+  onRevertOutcome,
   handleDeleteCall,
   formatAgeSex,
   getCallRowClass,
@@ -289,6 +291,17 @@ export default function ClinicTrackingCard({
               </DropdownMenu>
             </Dropdown>
           </div>
+
+          {call.outcome && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onRevertOutcome(call.id); }}
+              className="p-0 m-0 border-0 bg-transparent text-surface-light hover:text-status-blue transition-colors cursor-pointer flex items-center justify-center shrink-0 px-1"
+              aria-label={t('Reopen Call')}
+            >
+              <RotateCw className="w-4 h-4" />
+            </button>
+          )}
 
           {/* Primary Team (read-only) */}
           <div className="flex-1">

--- a/src/components/dispatch/trackingtablebase.tsx
+++ b/src/components/dispatch/trackingtablebase.tsx
@@ -32,7 +32,7 @@ export default function TrackingTableBase({
               <th className="px-3 py-2.5 text-left text-surface-faint w-40">{t('Chief Complaint')}</th>
               <th className="px-3 py-2.5 text-left text-surface-faint w-16">{t('A/S')}</th>
               <th className="px-3 py-2.5 text-left text-surface-faint w-48">{t('Location')}</th>
-              {showStatusColumn && <th className="px-3 py-2.5 text-left text-surface-faint w-28">{t('Status')}</th>}
+              {showStatusColumn && <th className="px-3 py-2.5 text-left text-surface-faint w-40">{t('Status')}</th>}
               <th className="px-3 py-2.5 text-left text-surface-faint">{t('Team')}</th>
               <th className="px-3 py-2.5 text-right text-surface-faint w-12"></th>
             </tr>

--- a/src/components/modals/event/transportunitmodal.tsx
+++ b/src/components/modals/event/transportunitmodal.tsx
@@ -1,0 +1,119 @@
+// components/modals/event/transportunitmodal.tsx
+"use client";
+
+import * as React from "react";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Input,
+} from "@heroui/react";
+
+import { useDispatchTerms } from "@/lib/dispatchVocabulary/context";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: () => void | Promise<void>;
+  value: string;
+  onValueChange: (value: string) => void;
+};
+
+export default function TransportUnitModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  value,
+  onValueChange,
+}: Props) {
+  const { t } = useDispatchTerms();
+  const [submitting, setSubmitting] = React.useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const inputClassNames = {
+    label: "text-surface-light mb-1",
+    inputWrapper: ["rounded-2xl px-4", "hover:bg-surface-deep"].join(" "),
+    input:
+      "text-surface-light outline-none focus:outline-none data-[focus=true]:outline-none",
+  } as const;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      placement="top-center"
+      backdrop="opaque"
+      hideCloseButton
+      radius="lg"
+      classNames={{
+        base: "rounded-2xl bg-surface-deepest text-surface-light mt-20",
+        header: "pb-0",
+        body: "py-4",
+        footer: "pt-0",
+      }}
+    >
+      <ModalContent>
+        {(close) => (
+          <form onSubmit={handleSubmit}>
+            <ModalHeader className="text-2xl font-bold text-surface">
+              {t('Enter Transport Unit')}
+            </ModalHeader>
+
+            <ModalBody>
+              <Input
+                autoFocus
+                label={t('Transport Unit #')}
+                labelPlacement="inside"
+                placeholder={t('Transport Unit #')}
+                variant="bordered"
+                size="lg"
+                radius="lg"
+                classNames={inputClassNames}
+                value={value}
+                onValueChange={onValueChange}
+                aria-label="Transport Unit #"
+              />
+            </ModalBody>
+
+            <ModalFooter className="flex justify-end gap-2">
+              <Button
+                onPress={() => {
+                  close();
+                  onClose();
+                }}
+                className="px-4 py-2 hover:bg-status-red/10 border border-status-red text-status-red"
+                variant="bordered"
+                radius="lg"
+              >
+                {t('Cancel')}
+              </Button>
+              <Button
+                type="submit"
+                radius="lg"
+                className="px-4 py-2 bg-accent hover:bg-accent/90 text-surface-light"
+                isDisabled={submitting}
+              >
+                {t('Submit')}
+              </Button>
+            </ModalFooter>
+          </form>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/lib/dispatchVocabulary/presets.ts
+++ b/src/lib/dispatchVocabulary/presets.ts
@@ -153,6 +153,13 @@ const CROWDCAD_FRENCH_TERMS: Record<string, string> = {
   'On Calls': 'En intervention',
   'On Break/Clinic': 'En pause/clinique',
   'Surge limit reached': "Seuil d'affluence atteint",
+  'Reopen Call': "Rouvrir l'appel",
+  'Revert this status and reopen the call?': "Annuler ce statut et rouvrir l'appel?",
+  'Revert this equipment status and reattach it to the team?': "Annuler ce statut d'équipement et le réattribuer à l'équipe?",
+  'Revert this supervisor detachment and reattach them to the call?': "Annuler le dégagement du superviseur et le réattribuer à l'appel?",
+  'Revert this clinic outcome?': 'Annuler ce résultat clinique?',
+  'Transport Unit #': "N° d'unité de transport",
+  'Enter Transport Unit': 'Unité de transport',
 };
 
 export const BUILTIN_PRESETS: Record<BuiltinPresetId, DispatchVocabularyPresetSummary> = {

--- a/src/lib/dispatchVocabulary/terms.ts
+++ b/src/lib/dispatchVocabulary/terms.ts
@@ -168,6 +168,13 @@ export const DISPATCH_TERMS: DispatchTerm[] = [
     'On Calls',
     'On Break/Clinic',
     'Surge limit reached',
+    'Reopen Call',
+    'Revert this status and reopen the call?',
+    'Revert this equipment status and reattach it to the team?',
+    'Revert this supervisor detachment and reattach them to the call?',
+    'Revert this clinic outcome?',
+    'Transport Unit #',
+    'Enter Transport Unit',
   ]),
 ];
 


### PR DESCRIPTION
## Summary
- Adds a revert (RotateCw) affordance for resolved/detached teams, equipment runs, and auto-detached supervisors on the Calls tab, and for resolved clinic outcomes on the Clinic tab — each with its own `confirm()` copy.
- Selecting "Transported" as a clinic outcome now prompts for an ambulance/transport unit number (`TransportUnitModal`); the resolved pill still just shows "Transported", but the log line reads "Transported by <unit>".
- Restyles the clinic status control into a single pill matching the "Pending" marker (icon now sits inside the pill, not floating beside it) and widens the Status column so the pill no longer clips.
- Adds French vocabulary + placeholders for every new dispatch-page string.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all touched files — clean (only pre-existing, unrelated warnings)
- [x] Manually traced existing Playwright BDD scenarios (`clinic-operations.feature`, `dispatch.feature`, `event-summary.feature`) against the changed selectors/markup — none exercise the new Transported-modal path or the restyled pill in a way that should break
- [ ] CI (Playwright E2E) — pending

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsQSUmU6Sx39wxKScaRQr5