### PR TITLE
fix(e2e): resolve equipment status select flake on main

### DIFF
--- a/tests/e2e/steps/dispatch-advanced.steps.ts
+++ b/tests/e2e/steps/dispatch-advanced.steps.ts
@@ -39,8 +39,17 @@ Given('I have a venue with location {string} and equipment {string} and am on th
 
 When('I change equipment {string} status to {string}', async ({ page }, equipName: string, newStatus: string) => {
   const card = page.getByTestId(`equipment-card-${equipName}`);
-  await card.locator('[aria-label="Status"]').click();
-  await page.locator('[role="listbox"]').getByText(newStatus, { exact: true }).click();
+  const trigger = card.locator('[aria-label="Status"]');
+  const option = page.locator('[role="listbox"]').getByText(newStatus, { exact: true });
+
+  // HeroUI's Select popover can spuriously close/remount right after opening (a known
+  // react-aria Popover timing quirk — see the guard on the team-status Dropdown in
+  // calltracking.tsx for the same root cause). Retry the open+click as a unit instead of
+  // clicking once, so a mid-flight remount just triggers another attempt.
+  await expect(async () => {
+    await trigger.click();
+    await option.click({ timeout: 2_000 });
+  }).toPass({ timeout: 15_000 });
 });
 
 Then('the equipment {string} should show status {string}', async ({ page }, equipName: string, status: string) => {


### PR DESCRIPTION
## Summary
- CI's "test" job failed on `main` right after PR #27 merged (`Equipment status can be changed on the dispatch board`), with `locator.click: Test timeout of 30000ms exceeded` / "element was detached from the DOM, retrying".
- Confirmed this is **pre-existing and unrelated to #27**: the identical failure occurs on the push-to-main run for the *previous* commit (`3a8115f`, before #27 was merged) — https://github.com/evanqua/crowdcad/actions/runs/32547430364.
- Root cause: HeroUI's `Select` popover can spuriously close/remount right after opening — the same react-aria Popover timing quirk already documented and guarded against for the team-status `Dropdown` in `calltracking.tsx` (`TEAM_STATUS_MENU_CLOSE_GUARD_MS`). The equipment-status test step clicked the trigger once then the option once, so a remount mid-click left Playwright retrying against a detached node until the test timeout.
- Fix: wrap the trigger-click + option-click in `expect(...).toPass()` so a remount just triggers another attempt, instead of failing after one shot.

I wasn't able to reproduce this locally — this sandbox blocks Next's trace-file write during `next build` regardless of build directory — so this is a well-reasoned fix based on the CI failure logs and this codebase's own prior fix for the identical root cause, not a locally-verified repro. Flagging that explicitly rather than claiming local verification.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint tests/e2e/steps/dispatch-advanced.steps.ts` — clean
- [ ] CI (Playwright E2E) — pending, watching this PR's run for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsQSUmU6Sx39wxKScaRQr5