### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+---
+
+## [1.5.0] - 2026-08-24
+
 ### Added
 
+- **Availability tracking and surge notifications** — a new availability/surge strip in the dispatch sidebar (and mobile/tablet layout) buckets teams into Available / On Break-Clinic / On Calls and shows a percent-on-calls meter that shifts from green to red at the event's configurable surge limit (`Event.surgeLimitPercent`, default 70%). Crossing the limit fires a one-time warning toast (also fixes react-toastify's `ToastContainer` never having been mounted on the dispatch page, which had silently no-opped every existing `toast.*` call).
 - **Multiple named clinics (complete)** — follow-up to the 1.4.0 foundation. `events.clinics` is now a real, schema-backed field (was silently dropped on PocketBase before) and is kept in sync with the venue's clinic-flagged posts via stable per-post `clinicId`s that survive a clinic being renamed. When a team is marked Transporting on a multi-clinic event, dispatch now prompts for which clinic the team is heading to instead of always routing to the first one; the chosen clinic is written onto the call immediately. Team-status pills, call chips, resolved/"Delivered" chips, activity logs, and the venue map's team tooltip all reflect the destination clinic; single-clinic events are visually unchanged. Map-builder clinic markers (canvas, location list, and the dispatch-side venue map) now consistently use a clinic icon driven by the real `isClinic` flag instead of a name-string heuristic in one of the three spots.
+- **Reversible call resolution and transport unit capture** — resolving a call is no longer a one-way action, and a new transport-unit modal captures which unit a team transported with, threaded through the dispatch vocabulary and tracking table.
+- **Centrally configurable status-card colors and opacities** — dispatch status-card colors and opacities now live in a single `src/lib/colorTokens.js` source of truth, consumed by `statusColors.ts` and `tailwind.config.js`, instead of being scattered across individual components.
+- PocketBase data interface control document (`docs/ICD.md`) — a backend-agnostic description of the PocketBase collections/fields and REST/SSE access, written so external integrations (including the in-progress TAK/ATAK integration) can read and write CrowdCAD data without depending on CrowdCAD's own frontend.
+- Dispatch vocabulary presets and terms from the profile refactor, including French translations for the new surge/availability strings.
+
+### Changed
+
+- Profile refactor: significant cleanup of the profile flow and its surrounding UI (see `#19` for full detail).
+
+### Removed
+
+- User avatar and profile photo upload/display logic, removed as part of the profile refactor.
+
+### Fixed
+
+- Equipment status select no longer flakes in E2E under rapid status changes.
+- Clinic call rows now align with call-tracking table behavior/columns.
+- PocketBase backend now persists the dispatch language preset on the users collection instead of losing it.
+- Event/venue creation UI colors now adapt correctly to light mode.
+- E2E suite no longer hangs on `networkidle` waits caused by a Firestore write firing on every page load.
+
+### Maintenance
+
+- Dependency updates within existing semver ranges; `@playwright/test` held back to fix a CI break it introduced.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dispatch-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dispatch-app",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@heroui/react": "^2.8.5",
         "@radix-ui/react-context-menu": "^2.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispatch-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Moves `[Unreleased]` into a real `## [1.5.0]` CHANGELOG section covering everything merged since v1.4.0: availability/surge tracking (#22), completed multi-clinic dispatch (#26), reversible call resolution + transport unit capture (#27), centrally configurable status-card colors (#30), the PocketBase ICD doc, and the profile refactor (#19), plus the #28 flake fix and #29 dependency bump.
- Bumps `package.json`/`package-lock.json` to `1.5.0` (MINOR — all changes are additive/backward-compatible per the repo's own versioning convention; no breaking changes since v1.4.0).

## Test plan
- [ ] CI (build/lint/type-check/E2E) passes