### PR TITLE
Restrict venue update/delete to the creator or a site admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Firestore rules: a non-admin organization member could previously update, share, or delete any other member's venue just by being in the same org. Only the venue's creator or a site admin can do that now; other org members still have read access.
+
 ---
 
 ## [1.5.0] - 2026-08-24

--- a/firestore.rules
+++ b/firestore.rules
@@ -86,19 +86,25 @@ service cloud.firestore {
       );
     }
 
+    // `let` bindings in Firestore Rules are only valid as top-level
+    // statements before a function's `return`, not nested inside a
+    // parenthesized boolean expression (that's a compile error, not just a
+    // style issue: `firebase deploy --only firestore:rules` rejects it).
+    // `let` is also lazily evaluated, only the first time the bound name is
+    // actually referenced, so declaring it before the `exists()` check
+    // below is safe: the `get()` never runs unless `exists()` is true, since
+    // `&&` short-circuits before `v`/`e` would otherwise be read.
     function isVenueVisibleToUser(venueId) {
+      let v = get(/databases/$(database)/documents/venues/$(venueId)).data;
       return exists(/databases/$(database)/documents/venues/$(venueId)) &&
-        (let v = get(/databases/$(database)/documents/venues/$(venueId)).data;
-          // if venue has orgId, require membership; otherwise public
-          !(v.orgId is string) || isOrgMember(v.orgId)
-        );
+        // if venue has orgId, require membership; otherwise public
+        (!(v.orgId is string) || isOrgMember(v.orgId));
     }
 
     function isEventVisibleToUser(eventId) {
+      let e = get(/databases/$(database)/documents/events/$(eventId)).data;
       return exists(/databases/$(database)/documents/events/$(eventId)) &&
-        (let e = get(/databases/$(database)/documents/events/$(eventId)).data;
-          !(e.orgId is string) || isOrgMember(e.orgId)
-        );
+        (!(e.orgId is string) || isOrgMember(e.orgId));
     }
 
     function isVenueOwner(venueId) {
@@ -107,10 +113,9 @@ service cloud.firestore {
     }
 
     function isEventOwnerOrOrgMember(eventId) {
+      let e = get(/databases/$(database)/documents/events/$(eventId)).data;
       return request.auth != null && exists(/databases/$(database)/documents/events/$(eventId)) &&
-        (let e = get(/databases/$(database)/documents/events/$(eventId)).data;
-          (e.userId == request.auth.uid) || (e.orgId is string && isOrgMember(e.orgId))
-        );
+        (e.userId == request.auth.uid || (e.orgId is string && isOrgMember(e.orgId)));
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,13 +20,16 @@ service cloud.firestore {
       }
     }
 
-    // Venues: require org membership to read; writes only by org members.
-    // Admins may also update/delete any venue (needed to wipe a deleted
-    // user's data from Profile > Admin > Manage Administrator Access).
+    // Venues: any org member can read. Only the venue's creator or a site
+    // admin can update, share, or delete it; org membership alone is not
+    // enough (a non-admin org member should not be able to edit or delete
+    // another member's venue). Admins may update/delete any venue (also
+    // needed to wipe a deleted user's data from Profile > Admin > Manage
+    // Administrator Access).
     match /venues/{venueId} {
       allow read: if isVenueVisibleToUser(venueId);
       allow create: if request.auth != null && request.resource.data.orgId is string && isOrgMember(request.resource.data.orgId);
-      allow update, delete: if isVenueOwnerOrOrgMember(venueId) || isRequestingUserAdmin();
+      allow update, delete: if isVenueOwner(venueId) || isRequestingUserAdmin();
     }
 
     // Events: require org membership to read; writes only by org members.
@@ -98,12 +101,9 @@ service cloud.firestore {
         );
     }
 
-    function isVenueOwnerOrOrgMember(venueId) {
+    function isVenueOwner(venueId) {
       return request.auth != null && exists(/databases/$(database)/documents/venues/$(venueId)) &&
-        (let v = get(/databases/$(database)/documents/venues/$(venueId)).data;
-          // owner check
-          (v.userId == request.auth.uid) || (v.orgId is string && isOrgMember(v.orgId))
-        );
+        get(/databases/$(database)/documents/venues/$(venueId)).data.userId == request.auth.uid;
     }
 
     function isEventOwnerOrOrgMember(eventId) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,7 +9,7 @@ service cloud.firestore {
     // - `members/{uid}` subcollection documents (optional future model).
     match /organizations/{orgId} {
       allow read: if isOrgMember(orgId);
-      allow create: if request.auth != null && request.resource.data.members is list && request.resource.data.members.hasAny([request.auth.uid]);
+      allow create: if request.auth != null && request.resource.data.get('members', null) is list && request.resource.data.members.hasAny([request.auth.uid]);
       allow update, delete: if isOrgMember(orgId);
 
       // Allow reading membership subdocs if member
@@ -45,7 +45,7 @@ service cloud.firestore {
     // added now since admin-initiated deletes need it to actually work.)
     match /dispatchLogs/{logId} {
       allow read, update, delete: if request.auth != null &&
-        (resource.data.userId == request.auth.uid || isRequestingUserAdmin());
+        (resource.data.get('userId', null) == request.auth.uid || isRequestingUserAdmin());
       allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
     }
 
@@ -65,10 +65,22 @@ service cloud.firestore {
       allow write: if isRequestingUserAdmin();
     }
 
+    // IMPORTANT: dot-notation field access (`doc.data.someField`) THROWS if
+    // the field is absent, it does not evaluate to null/false the way it
+    // would in JS. An uncaught throw anywhere in an `allow` expression
+    // denies the whole request, even branches joined with `||` that would
+    // otherwise have granted access (an error, not a boolean, doesn't
+    // participate in short-circuiting). Confirmed against the Firestore
+    // emulator: `get(...).data.isAdmin == true` threw "Property isAdmin is
+    // undefined on object" for any account without that field set, i.e.
+    // almost every non-admin user. Every function below that reads a field
+    // which may legitimately be absent on a given document uses
+    // `Map.get(key, default)` (safe) or the `in` operator (safe presence
+    // check) instead of bare dot access.
     function isRequestingUserAdmin() {
       return request.auth != null &&
         exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.get('isAdmin', false) == true;
     }
 
     // Fallback deny
@@ -77,8 +89,8 @@ service cloud.firestore {
       return request.auth != null && (
         exists(/databases/$(database)/documents/organizations/$(orgId)) &&
         (
-          get(/databases/$(database)/documents/organizations/$(orgId)).data.members is list &&
-          get(/databases/$(database)/documents/organizations/$(orgId)).data.members.hasAny([request.auth.uid])
+          get(/databases/$(database)/documents/organizations/$(orgId)).data.get('members', []) is list &&
+          get(/databases/$(database)/documents/organizations/$(orgId)).data.get('members', []).hasAny([request.auth.uid])
         )
         ||
         // or members subcollection
@@ -98,24 +110,24 @@ service cloud.firestore {
       let v = get(/databases/$(database)/documents/venues/$(venueId)).data;
       return exists(/databases/$(database)/documents/venues/$(venueId)) &&
         // if venue has orgId, require membership; otherwise public
-        (!(v.orgId is string) || isOrgMember(v.orgId));
+        (!('orgId' in v && v.orgId is string) || isOrgMember(v.orgId));
     }
 
     function isEventVisibleToUser(eventId) {
       let e = get(/databases/$(database)/documents/events/$(eventId)).data;
       return exists(/databases/$(database)/documents/events/$(eventId)) &&
-        (!(e.orgId is string) || isOrgMember(e.orgId));
+        (!('orgId' in e && e.orgId is string) || isOrgMember(e.orgId));
     }
 
     function isVenueOwner(venueId) {
       return request.auth != null && exists(/databases/$(database)/documents/venues/$(venueId)) &&
-        get(/databases/$(database)/documents/venues/$(venueId)).data.userId == request.auth.uid;
+        get(/databases/$(database)/documents/venues/$(venueId)).data.get('userId', null) == request.auth.uid;
     }
 
     function isEventOwnerOrOrgMember(eventId) {
       let e = get(/databases/$(database)/documents/events/$(eventId)).data;
       return request.auth != null && exists(/databases/$(database)/documents/events/$(eventId)) &&
-        (e.userId == request.auth.uid || (e.orgId is string && isOrgMember(e.orgId)));
+        (e.get('userId', null) == request.auth.uid || ('orgId' in e && e.orgId is string && isOrgMember(e.orgId)));
     }
   }
 }


### PR DESCRIPTION
## Summary
- Any org member could previously update, share, or delete another member's venue just by being in the same organization.
- Only the venue's creator (`userId`) or a site admin (`isAdmin`) can update/delete it now. Read access for org members is unchanged.
- This matters because an organization can now legitimately contain accounts that shouldn't have write access to every other member's venues (e.g. a temporary demo account added to an org for viewing purposes only, from the crowdcad.org wrapper repo).
- Also fixes two separate, pre-existing bugs found while verifying this against the Firestore emulator (this file has apparently never been through the emulator or a real deploy before):
  1. `isVenueVisibleToUser`, `isEventVisibleToUser`, and `isEventOwnerOrOrgMember` used `let` nested inside a parenthesized expression, which is invalid Firestore Rules syntax. The file as it stood would have failed `firebase deploy --only firestore:rules` outright.
  2. Several functions (`isRequestingUserAdmin`, `isOrgMember`, `isVenueVisibleToUser`, `isEventVisibleToUser`, `isVenueOwner`, `isEventOwnerOrOrgMember`, and the `dispatchLogs` rule) read fields like `isAdmin`/`orgId`/`userId` via bare dot access, which **throws** if the field is absent on a given document rather than evaluating to null/false. Confirmed via the emulator: `get(...).data.isAdmin == true` throws for any account without that field explicitly set (i.e. almost every non-admin user), and an uncaught throw denies the whole request even on branches joined with `||` that should have granted access. As written, this would have denied read/write access to the vast majority of real users the moment it deployed. Fixed with `Map.get(key, default)` / the `in` presence-check operator throughout.

## Test plan
- [x] Verified against the Firestore emulator (not Admin SDK, which bypasses rules) with a real test: a signed-in non-owner, non-admin org member gets permission-denied updating/deleting another member's venue, while still able to read it; the owner and an `isAdmin` account can still update/delete it. Ran this both with `isAdmin: false` explicitly set and with **no user doc at all** for the acting account (the realistic common case) — both pass.
- [x] Confirmed the full rules file now compiles under the emulator (it did not before the `let` fix)
- [x] Confirmed a public (org-less) venue is still readable by an unauthenticated request without throwing
- [ ] CI `test` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)